### PR TITLE
Wormbase fix

### DIFF
--- a/biolink/api/entityset/endpoints/slimmer.py
+++ b/biolink/api/entityset/endpoints/slimmer.py
@@ -47,12 +47,12 @@ class EntitySetSlimmer(Resource):
             prots = subjects
 
         logging.info('Looking for GO annotations to {}'.format(prots))
-            results = map2slim(subjects=prots,
-                               slim=slim,
-                               rows=200,
-                               exclude_automatic_assertions=True,
-                               object_category=category,
-                               **args)
+        results = map2slim(subjects=prots,
+                           slim=slim,
+                           rows=200,
+                           exclude_automatic_assertions=True,
+                           object_category=category,
+                           **args)
         # To the fullest extent possible return HGNC ids
         for result in results:
             for association in result['assocs']:


### PR DESCRIPTION
For slimmer to get GO annotations need to use WB not WormBase
For slimmer also need to switch out HGNC/NCBIGene/Ensembl for corresponding UniProt ID
For slimmer afterwards need to find HGNC id if possible

For homolog search need to use WormBase not WB
For homolog search need to eliminate ENSEMBL: homologs that duplicate the MOD gene (e.g. RGD:1306935 has a doppelganger)


