### PR TITLE
Removing homology result filtering introduced in #103

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -127,29 +127,11 @@ class GeneHomologAssociations(AbstractGeneAssociationResource):
         logging.info("looking for homologs to {}".format(id))
 
         homolog_args = homolog_parser.parse_args()
-        unfiltered_results = search_associations(
+        results = search_associations(
             subject_category='gene', object_category='gene',
             relation=homol_rel, subject=id,
             object_taxon=homolog_args.homolog_taxon,
             **homolog_parser.parse_args())
-
-        results = {'associations':[]}
-        for result in unfiltered_results:
-            if result == 'associations':
-                for association in unfiltered_results[result]:
-                    if 'provided_by' in association and 'panther' in association['provided_by'][0]:
-                        if 'object' in association and 'taxon' in association['object'] and 'id' in association['object']['taxon']:
-                            label = association['object']['id']
-                            taxon = association['object']['taxon']['id']
-                            if label.startswith('ENSEMBL:') and (taxon == 'NCBITaxon:9606' or taxon == 'NCBITaxon:10090' or taxon == 'NCBITaxon:10116' or taxon == 'NCBITaxon:7955' or taxon == 'NCBITaxon:7227' or taxon == 'NCBITaxon:6239' or taxon == 'NCBITaxon:4932' or taxon == 'NCBITaxon:559292'):
-                                logging.info('skipping homolog to {}'.format(label))
-                            else:
-                                # hooray, keep this
-                                results['associations'].append(association)
-                        else:
-                            logging.error('Missing taxon key in association {}'.format(association))
-                    else:
-                        logging.info('Ignore non-panther homology provided by {}'.format(association['provided_by'][0]))
         return results
 
 @ns.route('/gene/<id>/phenotypes/')


### PR DESCRIPTION
See https://github.com/biolink/biolink-api/pull/103/commits/190f38fdc0bb4e57e96b90dc0ecb214dc44d5f31

This was introduced to filter out additional redundant homology associations to ENSEMBL IDs
that were coming from sources other than panther.

We will first find some examples of this an explore alternate ways of filtering these