### PR TITLE
Taxon test

### DIFF
--- a/tests/bioentityset-taxon.feature
+++ b/tests/bioentityset-taxon.feature
@@ -6,6 +6,8 @@ Feature: homologous set of bioentities returned for a given gene all have a vali
     when the content is converted to JSON
       then the JSON should have some JSONPath "associations[*].object.taxon.id" of type "string"
       and the JSON should have some JSONPath "associations[*].object.taxon.label" of type "string"
+      and the gene "associations[*].object" homolog ID should be the authoritative source for taxon
+
     Examples: human genes
       | hgncID  |
       | HGNC:100 |

--- a/tests/bioentityset-taxon.feature
+++ b/tests/bioentityset-taxon.feature
@@ -1,0 +1,30 @@
+
+Feature: homologous set of bioentities returned for a given gene all have a valid taxon
+
+ Scenario Outline: User fetches all homologs for a human gene and they all have their taxon info
+    Given a path "/bioentity/gene/<hgncID>/homologs/?homology_type=O&fetch_objects=false&rows=200"
+    when the content is converted to JSON
+      then the JSON should have some JSONPath "associations[*].object.taxon.id" of type "string"
+      and the JSON should have some JSONPath "associations[*].object.taxon.label" of type "string"
+    Examples: human genes
+      | hgncID  |
+      | HGNC:100 |
+      | HGNC:16397 |
+      | HGNC:11593 |
+      | HGNC:4739 |
+      | HGNC:3262 |
+      | HGNC:14581 |
+      | HGNC:11604 |
+      | HGNC:3686 |
+      | HGNC:583 |
+      | HGNC:7 |
+      | HGNC:11730 |
+      | HGNC:7881 |
+      | HGNC:12774 |
+      | HGNC:2908 |
+      | HGNC:10848 |
+      | HGNC:11773 |
+      | HGNC:11998 |
+      | HGNC:8620 |
+      | HGNC:3009 |
+      | HGNC:6769 |

--- a/tests/steps/route-data.py
+++ b/tests/steps/route-data.py
@@ -29,7 +29,7 @@ def get_and_process(context, url):
             context.content = resp.text
             context.content_json = resp.json()
 
-            
+
 
 ###
 ### Definitions.
@@ -93,6 +93,41 @@ def step_impl(context, jsonpath):
         #print(res)
         assert res
 
+@then('the JSON should have some JSONPath "{jsonpath}" of type "{thing}"')
+def step_impl(context, jsonpath, thing):
+    if not context.content_json :
+        ## Apparently no JSON at all...
+        assert True is False
+    else:
+        jsonpath_expr = jsonpath_rw.parse(jsonpath)
+        results = jsonpath_expr.find(context.content_json)
+        if (len(results)) == 0:
+            assert True is False
+        else:
+            is_found = False
+            for res in results:
+                if type(thing) == str and thing == "string":
+                    is_found = True
+                elif type(thing) == int and thing == "number":
+                    is_found = True
+                elif type(thing) == float and thing == "number":
+                    is_found = True
+                elif type(thing) == True and thing == "boolean":
+                    is_found = True
+                elif type(thing) == False and thing == "boolean":
+                    is_found = True
+                elif type(thing) == dict and thing == "object":
+                    is_found = True
+                elif type(thing) == list and thing == "array":
+                    is_found = True
+                elif thing is None and thing == "null":
+                    is_found = True
+                else:
+                    ## Not a thing we know how to deal with yet.
+                    logging.error("Cannot interpret: {}".format(thing))
+                    assert True is False
+            assert is_found is True
+
 @then('the JSON should have JSONPath "{jsonpath}" equal to "{thing}" "{value}"')
 def step_impl(context, jsonpath, thing, value):
     if not context.content_json :
@@ -138,7 +173,7 @@ def step_impl(context, jsonpath, thing, value):
                         is_found = True
                 elif thing == "float":
                     if res.value == float(value):
-                        is_found = True                        
+                        is_found = True
                 else:
                     ## Not a thing we know how to deal with yet.
                     logging.error("Cannot interpret: {}".format(thing))
@@ -171,10 +206,9 @@ def step_impl(context, jsonpath, thing, value):
                         is_found = True
                 elif thing == "float":
                     if float(value) in res.value:
-                        is_found = True                        
+                        is_found = True
                 else:
                     ## Not a thing we know how to deal with yet.
                     logging.error("Cannot interpret: {}".format(thing))
                     assert True is False
             assert is_found is True
-            

--- a/tests/steps/route-data.py
+++ b/tests/steps/route-data.py
@@ -106,27 +106,61 @@ def step_impl(context, jsonpath, thing):
         else:
             is_found = False
             for res in results:
-                if type(thing) == str and thing == "string":
+                if type(res.value) == str and thing == "string":
                     is_found = True
-                elif type(thing) == int and thing == "number":
+                elif type(res.value) == int and thing == "number":
                     is_found = True
-                elif type(thing) == float and thing == "number":
+                elif type(res.value) == float and thing == "number":
                     is_found = True
-                elif type(thing) == True and thing == "boolean":
+                elif type(res.value) == True and thing == "boolean":
                     is_found = True
-                elif type(thing) == False and thing == "boolean":
+                elif type(res.value) == False and thing == "boolean":
                     is_found = True
-                elif type(thing) == dict and thing == "object":
+                elif type(res.value) == dict and thing == "object":
                     is_found = True
-                elif type(thing) == list and thing == "array":
+                elif type(res.value) == list and thing == "array":
                     is_found = True
-                elif thing is None and thing == "null":
+                elif res.value is None and thing == "null":
                     is_found = True
                 else:
                     ## Not a thing we know how to deal with yet.
-                    logging.error("Cannot interpret: {}".format(thing))
+                    logging.error("Cannot interpret value: {}".format(res.value))
                     assert True is False
             assert is_found is True
+
+@then('the gene "{jsonpath}" homolog ID should be the authoritative source for taxon')
+def step_impl(context, jsonpath):
+        if not context.content_json:
+            ## Apparently no JSON at all...
+            assert True is False
+        else:
+            json_expr = jsonpath_rw.parse(jsonpath)
+            results = json_expr.find(context.content_json)
+            if (len(results)) == 0:
+                assert True is False
+            else:
+                is_okay = True
+                for res in results:
+                    print(str(res.value))
+                    geneID = res.value['id']
+                    taxon = res.value['taxon']['id']
+                    print(geneID)
+                    print(taxon)
+                    if taxon == 'NCBITaxon:9606' and not geneID.startswith('HGNC'):
+                        is_okay = False
+                    elif taxon == 'NCBITaxon:10090' and not geneID.startswith('MGI'):
+                        is_okay = False
+                    elif taxon == 'NCBITaxon:10116' and not geneID.startswith('RGD'):
+                        is_okay = False
+                    elif taxon == 'NCBITaxon:7955' and not geneID.startswith('ZFIN'):
+                        is_okay = False
+                    elif taxon == 'NCBITaxon:7227' and not (geneID.startswith('FlyBase') or geneID.startswith('FB')):
+                        is_okay = False
+                    elif taxon == 'NCBITaxon:6239' and not (geneID.startswith('WormBase') or geneID.startswith('WB')):
+                        is_okay = False
+                    elif (taxon == 'NCBITaxon:4932' or taxon == 'NCBITaxon:559292') and not geneID.startswith('SGD'):
+                        is_okay = False
+                assert is_okay is True
 
 @then('the JSON should have JSONPath "{jsonpath}" equal to "{thing}" "{value}"')
 def step_impl(context, jsonpath, thing, value):


### PR DESCRIPTION
Tests that both the taxon ID and the taxon label are filled in. Locally seeing a problem with ZFIN:ZDB-GENE-121228-1 (taxon data is null) when searching for homologs to HGNC:11593, but not on the Monarch server itself. The Monarch server also returns one fewer homologs results (33 rather than 34). 

It also checks to be sure the ID of the homolog is from the authoritative source (the cliqueleader)