### PR TITLE
Add a landing page for biolink-api

### DIFF
--- a/biolink/api/restplus.py
+++ b/biolink/api/restplus.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 api = Api(version='0.1.1', title='BioLink API',
           license='BSD3',
           contact='cjmungall@lbl.gov',
-          description='API integration layer for linked biological objects.\n\n __Source:__ https://github.com/monarch-initiative/biolink-api/')
+          description='API integration layer for linked biological objects.\n\n __Source:__ https://github.com/biolink/biolink-api/')
 
 
 @api.errorhandler

--- a/biolink/app.py
+++ b/biolink/app.py
@@ -2,7 +2,8 @@ import logging.config
 import os
 
 import flask as f
-from flask import Flask, Blueprint
+from flask import Flask, Blueprint, request
+from flask import render_template
 from flask_cors import CORS, cross_origin
 from biolink import settings
 from biolink.api.bio.endpoints.bioentity import ns as bio_objects_namespace
@@ -76,11 +77,11 @@ db.init_app(app)
 #from ontobio.ontol_factory import OntologyFactory
 #factory = OntologyFactory()
 #ont = factory.create()
-    
+
 
 @app.route("/")
 def hello():
-    return "<h1 style='color:blue'>Hello There!</h1>"
+    return render_template('index.html', base_url=request.base_url)
 
 def main():
     #initialize_app(app)

--- a/biolink/static/main.css
+++ b/biolink/static/main.css
@@ -1,0 +1,15 @@
+#container {
+  font-family: "Droid Sans", sans-serif;
+}
+
+#title {
+  margin: 10px;
+}
+
+#description {
+  margin: 10px;
+}
+
+#keyword_span {
+  margin-right: 5px;
+}

--- a/biolink/templates/index.html
+++ b/biolink/templates/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
+    <title>BioLink API</title>
+  </head>
+  <body>
+    <div id="container">
+      <div id="title">
+        <h1>BioLink API</h1>
+      </div>
+      <div id="description">
+        <p>API integration layer for linked biological objects.</p>
+        <p><span id="keyword_span"><strong>Source:</strong></span><a href="https://github.com/biolink/biolink-api">https://github.com/biolink/biolink-api</a></p>
+        <p><span id="keyword_span"><strong>Swagger UI:</strong></span><a href="/api">{{ base_url }}api</a>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #149 

The landing page is bare bone HTML with links to the GitHub repository and Swagger UI.

Also updated the link to repository displayed in Swagger UI from `https://github.com/monarch-initiative/biolink-api` to `https://github.com/biolink/biolink-api`.

