### PR TITLE
Fix for consistent behavior for URLs with a trailing slash

### DIFF
--- a/biolink/app.py
+++ b/biolink/app.py
@@ -51,6 +51,7 @@ from biolink.api.restplus import api
 from biolink.database import db
 
 app = Flask(__name__)
+app.url_map.strict_slashes = False
 CORS(app)
 logging.config.fileConfig('logging.conf')
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #229 

Flask provides a way to configure this behavior.

When registering a route, if we specify `strict_slashes=False` then the behavior is as expected.

But to configure this at an app level: 
```
app = Flask(__name__)
app.url_map.strict_slashes = False
```
