### PR TITLE
Add the ability to get association counts for generic routes

### DIFF
--- a/biolink/api/bio/association_counts.py
+++ b/biolink/api/bio/association_counts.py
@@ -1,0 +1,82 @@
+from ontobio.golr.golr_associations import search_associations
+from ontobio.vocabulary.relations import HomologyTypes
+
+HOMOLOG_TYPES = [
+    HomologyTypes.Ortholog.value,
+    HomologyTypes.LeastDivergedOrtholog.value,
+    HomologyTypes.Homolog.value,
+    HomologyTypes.Paralog.value,
+    HomologyTypes.InParalog.value,
+    HomologyTypes.OutParalog.value,
+    HomologyTypes.Ohnolog.value,
+    HomologyTypes.Xenolog.value
+]
+INTERACTS_WITH = 'RO:0002434'
+
+def get_association_counts(id):
+    """
+    For a given CURIE, get the number of associations by each category.
+
+    Note: Experimental
+    """
+    count_map = {}
+    subject_associations = search_associations(
+        fq={'subject_closure': id},
+        facet_pivot_fields=['{!stats=piv1}object_category', 'relation'],
+        stats=True,
+        stats_field='{!tag=piv1 calcdistinct=true distinctValues=false}object'
+    )
+    object_associations = search_associations(
+        fq={'object_closure': id},
+        facet_pivot_fields=['{!stats=piv1}subject_category', 'relation'],
+        stats=True,
+        stats_field='{!tag=piv1 calcdistinct=true distinctValues=false}subject'
+    )
+    subject_pivot_counts = subject_associations['facet_pivot']['object_category,relation']
+    object_pivot_counts = object_associations['facet_pivot']['subject_category,relation']
+
+    for category in subject_pivot_counts:
+        type = category['value']
+        if type == 'gene':
+            count_map['gene'] = category['stats']['stats_fields']['object']['countDistinct']
+            if 'pivot' in category:
+                for relation in category['pivot']:
+                    if relation['value'] in HOMOLOG_TYPES:
+                        # homolog
+                        if 'homolog' not in count_map:
+                            count_map['homolog'] = relation['stats']['stats_fields']['object']['countDistinct']
+                        else:
+                            count_map['homolog'] += relation['stats']['stats_fields']['object']['countDistinct']
+                    elif relation['value'] == INTERACTS_WITH:
+                        # interaction
+                        count_map['interaction'] = relation['stats']['stats_fields']['object']['countDistinct']
+                    else:
+                        # ignore the rest of the relation counts as they are to be aggregated at higher level
+                        pass
+        else:
+            count_map[type] = category['stats']['stats_fields']['object']['countDistinct']
+
+    for category in object_pivot_counts:
+        type = category['value']
+        if type == 'gene':
+            if 'gene' not in count_map:
+                count_map['gene'] = category['stats']['stats_fields']['subject']['countDistinct']
+            if 'homolog' not in count_map:
+                if 'pivot' in category:
+                    for relation in category['pivot']:
+                        if relation['value'] in HOMOLOG_TYPES:
+                            # homolog
+                            if 'homolog' not in count_map:
+                                count_map['homolog'] = relation['stats']['stats_fields']['subject']['countDistinct']
+                            else:
+                                count_map['homolog'] += relation['stats']['stats_fields']['subject']['countDistinct']
+                        elif relation['value'] == INTERACTS_WITH:
+                            # interaction
+                            count_map['interaction'] = relation['stats']['stats_fields']['object']['countDistinct']
+                        else:
+                            # ignore the rest of the relation counts as they are to be aggregated at higher level
+                            pass
+        else:
+            count_map[type] = category['stats']['stats_fields']['subject']['countDistinct']
+
+    return count_map

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -106,10 +106,13 @@ class GenericObjectByType(Resource):
         """
         Return basic info on an object for a given type
         """
+        args = self.parser.parse_args()
         if type == TYPE_DISEASE:
             ret_val = marshal(scigraph.bioobject(id, type), disease_object), 200
         else:
             ret_val = marshal(scigraph.bioobject(id, type), bio_object), 200
+        if args['get_association_counts']:
+            ret_val[0]['association_counts'] = get_association_counts(id, type)
         return ret_val
 
 class GenericAssociations(Resource):

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -99,7 +99,7 @@ class GenericObject(Resource):
         if args['get_association_counts']:
             counts = get_association_counts(id)
             # TODO
-            obj.__setattr__('association_stats', counts)
+            obj.__setattr__('association_counts', counts)
 
         return(obj)
 
@@ -121,7 +121,7 @@ class GenericObjectByType(Resource):
         if args['get_association_counts']:
             counts = get_association_counts(id)
             # TODO
-            obj.__setattr__('association_stats', counts)
+            obj.__setattr__('association_counts', counts)
 
         return(obj)
 

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -123,6 +123,7 @@ bio_object_core = api.inherit('BioObjectCore', named_object_core, {
 })
 bio_object = api.inherit('BioObject', named_object, {
     'taxon': fields.Nested(taxon, description='Taxon to which the object belongs'),
+    'association_counts': fields.Raw(description='association counts'),
     'xrefs': fields.List(fields.String, description='Database cross-references. These are usually CURIEs, but may also be URLs. E.g. ENSEMBL:ENSG00000099940 '),
     
 })

--- a/biomodel/core.py
+++ b/biomodel/core.py
@@ -435,9 +435,11 @@ class BioObject(NamedObject):
     def __init__(self,
                  id=None,
                  taxon=None,
+                 association_counts=None,
                  **kwargs):
         super(BioObject, self).__init__(id, **kwargs)
         self.taxon=taxon
+        self.association_counts=association_counts
 
 
     """
@@ -457,6 +459,8 @@ class BioObject(NamedObject):
             obj.taxon = Taxon.from_json(json_obj['taxon'])
         if 'description' in json_obj:
             obj.description = json_obj['description']
+        if 'association_counts' in json_obj:
+            obj.association_counts = json_obj['association_counts']
         return obj
 
 class AnnotationExtension():

--- a/biomodel/core.py
+++ b/biomodel/core.py
@@ -434,11 +434,13 @@ class BioObject(NamedObject):
                  taxon=None,
                  inheritance=None,
                  clinical_modifiers=None,
+                 association_counts=None,
                  **kwargs):
         super(BioObject, self).__init__(id, **kwargs)
         self.taxon = taxon
         self.inheritance = inheritance
         self.clinical_modifiers = clinical_modifiers
+        self.association_counts = association_counts
 
 
     """
@@ -462,6 +464,8 @@ class BioObject(NamedObject):
             obj.inheritance = json_obj['inheritance']
         if 'clinical_modifiers' in json_obj:
             obj.clinical_modifiers = json_obj['clinical_modifiers']
+        if 'association_counts' in json_obj:
+            obj.association_counts = json_obj['association_counts']
         return obj
 
 class AnnotationExtension():


### PR DESCRIPTION
Add ability to get association counts for:
- `/bioentity/<id>`
- `bioentity/<type>/<id>`

The response looks like so:
```
{
  "taxon": {
    "id": "NCBITaxon:9606",
    "label": "Homo sapiens"
  },
  "association_counts": {
    "gene": 79,
    "interaction": 58,
    "homolog": 51,
    "phenotype": 84,
    "anatomical entity": 20,
    "biological process": 14,
    "pathway": 6,
    "disease": 4,
    "publication": 32,
    "variant": 13
  },
  "xrefs": null,
  "description": null,
  "categories": [
    "gene",
    "sequence feature"
  ],
  "types": null,
  "synonyms": null,
  "deprecated": null,
  "replaced_by": null,
  "consider": null,
  "id": "HGNC:18603",
  "label": "COL25A1"
}
```

**Note:** This PR is experimental and would like feedback from @cmungall @kshefchek @putmantime 