### PR TITLE
Configuration of endpoints in BioLink (closed)

### DIFF
--- a/biolink/app.py
+++ b/biolink/app.py
@@ -1,64 +1,30 @@
 import logging.config
-import os
-
-import flask as f
+import os, importlib
 from flask import Flask, Blueprint, request
 from flask import render_template
 from flask_cors import CORS, cross_origin
 from biolink import settings
-from biolink.api.bio.endpoints.bioentity import ns as bio_objects_namespace
-from biolink.api.link.endpoints.associations_from import ns as associations_from_namespace
-from biolink.api.link.endpoints.find_associations import ns as find_associations_namespace
-from biolink.api.search.endpoints.entitysearch import ns as entity_search_namespace
-
-from biolink.api.ontol.endpoints.ontology_endpoint import ns as ontology_endpoint_namespace
-
-from biolink.api.ontol.endpoints.subgraph import ns as ontol_subgraph_namespace
-from biolink.api.ontol.endpoints.termstats import ns as ontol_termstats_namespace
-from biolink.api.ontol.endpoints.labeler import ns as ontol_labeler
-#from biolink.api.ontol.endpoints.enrichment import ns as ontol_enrichment_namespace
-
-from biolink.api.entityset.endpoints.summary import ns as entityset_summary_namespace
-from biolink.api.entityset.endpoints.slimmer import ns as entityset_slimmer_namespace
-from biolink.api.entityset.endpoints.geneset_homologs import ns as geneset_homologs_namespace
-from biolink.api.entityset.endpoints.overrepresentation import ns as overrepresentation
-from biolink.api.nlp.endpoints.annotate import ns as nlp_annotate_namespace
-from biolink.api.graph.endpoints.node import ns as graph_node_namespace
-
-from biolink.api.ontol.endpoints.subgraph import ns as subgraph_namespace
-
-from biolink.api.mart.endpoints.mart import ns as mart_namespace
-
-from biolink.api.cam.endpoints.cam_endpoint import ns as cam_namespace
-from biolink.api.owl.endpoints.ontology import ns as owl_ontology_namespace
-from biolink.api.patient.endpoints.individual import ns as patient_individual_namespace
-from biolink.api.identifier.endpoints.prefixes import ns as identifier_prefixes_namespace
-from biolink.api.identifier.endpoints.mapper import ns as identifier_prefixes_mapper
-
-from biolink.api.genome.endpoints.region import ns as genome_region_namespace
-from biolink.api.pair.endpoints.pairsim import ns as pair_pairsim_namespace
-
-from biolink.api.evidence.endpoints.graph import ns as evidence_graph_namespace
-from biolink.api.relations.endpoints.relation_usage import ns as relation_usage_namespace
-
-from biolink.api.variation.endpoints.variantset import ns as variation_variantset_namespace
-
-from biolink.api.pub.endpoints.pubs import ns as pubs_namespace
-
-
 from biolink.api.restplus import api
-
 from biolink.database import db
+
+logging.config.fileConfig('logging.conf')
+log = logging.getLogger(__name__)
+
+config = settings.get_biolink_config()
+module_list = config.get('biolink_modules')
+
+for module in module_list:
+    try:
+        m = importlib.import_module(module)
+        ns = getattr(m, 'ns')
+    except ImportError:
+        log.error("Cannot import module: {}".format(module))
+
 
 app = Flask(__name__)
 app.url_map.strict_slashes = False
 CORS(app)
-logging.config.fileConfig('logging.conf')
-log = logging.getLogger(__name__)
 
-
-#def configure_app(flask_app):
-#app.config['SERVER_NAME'] = settings.FLASK_SERVER_NAME
 app.config['SQLALCHEMY_DATABASE_URI'] = settings.SQLALCHEMY_DATABASE_URI
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = settings.SQLALCHEMY_TRACK_MODIFICATIONS
 app.config['SWAGGER_UI_DOC_EXPANSION'] = settings.RESTPLUS_SWAGGER_UI_DOC_EXPANSION
@@ -66,9 +32,6 @@ app.config['RESTPLUS_VALIDATE'] = settings.RESTPLUS_VALIDATE
 app.config['RESTPLUS_MASK_SWAGGER'] = settings.RESTPLUS_MASK_SWAGGER
 app.config['ERROR_404_HELP'] = settings.RESTPLUS_ERROR_404_HELP
 
-
-#def initialize_app(flask_app):
-#    configure_app(flask_app)
 
 blueprint = Blueprint('api', __name__, url_prefix='/api')
 api.init_app(blueprint)

--- a/biolink/settings.py
+++ b/biolink/settings.py
@@ -1,3 +1,5 @@
+import yaml
+
 # Flask settings
 FLASK_SERVER_NAME = 'localhost:8888'
 FLASK_DEBUG = True  # Do not use debug mode in production
@@ -11,3 +13,14 @@ RESTPLUS_ERROR_404_HELP = False
 # SQLAlchemy settings
 SQLALCHEMY_DATABASE_URI = 'sqlite:///db.sqlite'
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+CONFIG = 'conf/config.yaml'
+
+biolink_config = None
+
+def get_biolink_config():
+    global biolink_config
+    if biolink_config is None:
+        with open(CONFIG, 'r') as f:
+            biolink_config = yaml.load(f)
+    return biolink_config

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -37,4 +37,33 @@ ontologies:
   - id: monarch
     handle: data/monarch.json
     pre_load: true
+biolink_modules:
+  - 'biolink.api.bio.endpoints.bioentity'
+  - 'biolink.api.link.endpoints.associations_from'
+  - 'biolink.api.link.endpoints.find_associations'
+  - 'biolink.api.search.endpoints.entitysearch'
+  - 'biolink.api.ontol.endpoints.ontology_endpoint'
+  - 'biolink.api.ontol.endpoints.subgraph'
+  - 'biolink.api.ontol.endpoints.termstats'
+  - 'biolink.api.ontol.endpoints.labeler'
+  - 'biolink.api.ontol.endpoints.enrichment'
+  - 'biolink.api.entityset.endpoints.summary'
+  - 'biolink.api.entityset.endpoints.slimmer'
+  - 'biolink.api.entityset.endpoints.geneset_homologs'
+  - 'biolink.api.entityset.endpoints.overrepresentation'
+  - 'biolink.api.nlp.endpoints.annotate'
+  - 'biolink.api.graph.endpoints.node'
+  - 'biolink.api.ontol.endpoints.subgraph'
+  - 'biolink.api.mart.endpoints.mart'
+  - 'biolink.api.cam.endpoints.cam_endpoint'
+  - 'biolink.api.owl.endpoints.ontology'
+  - 'biolink.api.patient.endpoints.individual'
+  - 'biolink.api.identifier.endpoints.prefixes'
+  - 'biolink.api.identifier.endpoints.mapper'
+  - 'biolink.api.genome.endpoints.region'
+  - 'biolink.api.pair.endpoints.pairsim'
+  - 'biolink.api.evidence.endpoints.graph'
+  - 'biolink.api.relations.endpoints.relation_usage'
+  - 'biolink.api.variation.endpoints.variantset'
+  - 'biolink.api.pub.endpoints.pubs'
 


### PR DESCRIPTION
Added the ability to initialize routes as dictated by `config.yaml`.
Currently the config.yaml includes all routes (by default). 

The idea is to have an implementation specific config.yaml (for example GO BioLink API specific config.yaml) that defines which routes to initialize.

@cmungall @lpalbou Related to #235. Let me know what you think.

If this approach seems feasible then I can start breaking `biolink.api.bio.endpoints.bioentity` into resource specific chunks. This way it would be easy to mix and match different parts of the API and show only the relevant routes.