### PR TITLE
Configuration of endpoints as driven by config.yaml

### DIFF
--- a/biolink/api/TEMPLATE/endpoints/RESOURCE.py
+++ b/biolink/api/TEMPLATE/endpoints/RESOURCE.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('TEMPLATE/RESOURCE', description='foo bar')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<term>')
 class Foo(Resource):
 
     @api.expect(parser)

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -1002,7 +1002,6 @@ class AnatomyGeneAssociations(Resource):
         """
         Returns genes associated with a given anatomy
         """
-        print("ARGS: {}".format(core_parser.parse_args))
         return search_associations(
             subject_category='gene',
             object_category='anatomical entity',

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -20,9 +20,6 @@ import json
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('bioentity', description='Retrieval of domain entities plus associations')
-
-
 basic_parser = api.parser()
 basic_parser.add_argument('start', type=int, required=False, default=0, help='beginning row')
 basic_parser.add_argument('rows', type=int, required=False, default=100, help='number of rows')
@@ -81,7 +78,6 @@ def get_object_genotype(id, **args):
 
         return(obj)
 
-@ns.route('/<id>')
 @api.doc(params={'id': 'id, e.g. NCBIGene:84570'})
 class GenericObject(Resource):
 
@@ -94,7 +90,6 @@ class GenericObject(Resource):
         obj = scigraph.bioobject(id)
         return(obj)
 
-@ns.route('/<type>/<id>')
 @api.param('id', 'id, e.g. NCBIGene:84570')
 @api.param('type', 'bioentity type', enum=[TYPE_GENE, TYPE_VARIANT, TYPE_GENOTYPE, TYPE_PHENOTYPE,
                                            TYPE_DISEASE, TYPE_GOTERM, TYPE_PATHWAY, TYPE_ANATOMY,
@@ -110,7 +105,6 @@ class GenericObjectByType(Resource):
         obj = scigraph.bioobject(id)
         return(obj)
 
-@ns.route('/<id>/associations')
 class GenericAssociations(Resource):
 
     @api.expect(core_parser)
@@ -125,7 +119,6 @@ class GenericAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/interactions')
 @api.doc(params={'id': 'id, e.g. NCBIGene:3630. Equivalent IDs can be used with same results'})
 class GeneInteractions(Resource):
 
@@ -144,7 +137,6 @@ class GeneInteractions(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/homologs')
 @api.doc(params={'id': 'id, e.g. NCBIGene:3630. Equivalent IDs can be used with same results'})
 class GeneHomologAssociations(Resource):
 
@@ -173,7 +165,6 @@ class GeneHomologAssociations(Resource):
             **homolog_args
         )
 
-@ns.route('/gene/<id>/phenotypes')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750. Equivalent IDs can be used with same results'})
 class GenePhenotypeAssociations(Resource):
 
@@ -192,7 +183,6 @@ class GenePhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/diseases')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750. Equivalent IDs can be used with same results'})
 class GeneDiseaseAssociations(Resource):
 
@@ -211,7 +201,6 @@ class GeneDiseaseAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/pathways')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:50846. Equivalent IDs can be used with same results'})
 class GenePathwayAssociations(Resource):
 
@@ -230,7 +219,6 @@ class GenePathwayAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/expression/anatomy')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750. Equivalent IDs can be used with same results'})
 class GeneExpressionAssociations(Resource):
 
@@ -249,7 +237,6 @@ class GeneExpressionAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/anatomy')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:13434'})
 class GeneAnatomyAssociations(Resource):
 
@@ -268,7 +255,6 @@ class GeneAnatomyAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/genotypes')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. ZFIN:ZDB-GENE-980526-166'})
 class GeneGenotypeAssociations(Resource):
 
@@ -287,7 +273,6 @@ class GeneGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/function')
 @api.doc(params={'id': 'id, e.g. NCBIGene:6469. Equivalent IDs can be used with same results'})
 class GeneFunctionAssociations(Resource):
 
@@ -339,7 +324,6 @@ class GeneFunctionAssociations(Resource):
                 assocs['associations'] += pr_assocs['associations']
         return assocs
 
-@ns.route('/gene/<id>/literature')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750'})
 class GeneLiteratureAssociations(Resource):
 
@@ -359,7 +343,6 @@ class GeneLiteratureAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/models')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:17988'})
 class GeneModelAssociations(Resource):
 
@@ -379,7 +362,6 @@ class GeneModelAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/ortholog/phenotypes')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750'})
 class GeneOrthologPhenotypeAssociations(Resource):
 
@@ -399,7 +381,6 @@ class GeneOrthologPhenotypeAssociations(Resource):
         )
 
 
-@ns.route('/gene/<id>/ortholog/diseases')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750'})
 class GeneOrthologDiseaseAssociations(Resource):
 
@@ -417,7 +398,6 @@ class GeneOrthologDiseaseAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/gene/<id>/variants')
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. HGNC:10896'})
 class GeneVariantAssociations(Resource):
 
@@ -436,7 +416,6 @@ class GeneVariantAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/phenotypes')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, Orphanet:1934, DOID:678. Equivalent IDs can be used with same results'})
 class DiseasePhenotypeAssociations(Resource):
 
@@ -458,7 +437,6 @@ class DiseasePhenotypeAssociations(Resource):
             fcs['closure_bin'] = create_closure_bin(fcs.get('object_closure'))
         return results
 
-@ns.route('/disease/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 class DiseaseGeneAssociations(Resource):
 
@@ -477,7 +455,6 @@ class DiseaseGeneAssociations(Resource):
             **core_parser.parse_args())
 
 
-@ns.route('/disease/<id>/treatment')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. DOID:2841 (asthma). Equivalent IDs not yet supported'})
 class DiseaseSubstanceAssociations(Resource):
 
@@ -492,7 +469,6 @@ class DiseaseSubstanceAssociations(Resource):
         """
         return condition_to_drug(id)
 
-@ns.route('/disease/<id>/models')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 class DiseaseModelAssociations(Resource):
 
@@ -525,7 +501,6 @@ class DiseaseModelAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/models/<taxon>')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 @api.doc(params={'taxon': 'CURIE of organism taxonomy class to constrain models, e.g NCBITaxon:10090 (M. musculus).\n\n Higher level taxa may be used'})
 class DiseaseModelTaxonAssociations(Resource):
@@ -550,7 +525,6 @@ class DiseaseModelTaxonAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/genotypes')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. Orphanet:399158, DOID:0080008. Equivalent IDs can be used with same results'})
 class DiseaseGenotypeAssociations(Resource):
 
@@ -570,7 +544,6 @@ class DiseaseGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/literature')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 class DiseaseLiteratureAssociations(Resource):
 
@@ -590,7 +563,6 @@ class DiseaseLiteratureAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/models')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 class DiseaseModelAssociations(Resource):
 
@@ -610,7 +582,6 @@ class DiseaseModelAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/pathways')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. DOID:4450. Equivalent IDs can be used with same results'})
 class DiseasePathwayAssociations(Resource):
 
@@ -629,7 +600,6 @@ class DiseasePathwayAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/disease/<id>/variants')
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
 class DiseaseVariantAssociations(Resource):
 
@@ -649,7 +619,6 @@ class DiseaseVariantAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/phenotype/<id>/anatomy')
 @api.doc(params={'id': 'CURIE identifier of phenotype, e.g. MP:0008521. Equivalent IDs can be used with same results'})
 class PhenotypeAnatomyAssociations(Resource):
     # Note: This depends on https://github.com/biolink/biolink-api/issues/122
@@ -668,7 +637,6 @@ class PhenotypeAnatomyAssociations(Resource):
         objs = scigraph.phenotype_to_entity_list(id)
         return objs
 
-@ns.route('/phenotype/<id>/diseases')
 @api.doc(params={'id': 'CURIE identifier of phenotype, e.g. HP:0007359. Equivalent IDs can be used with same results'})
 class PhenotypeDiseaseAssociations(Resource):
 
@@ -693,7 +661,6 @@ class PhenotypeDiseaseAssociations(Resource):
         return results
 
 
-@ns.route('/phenotype/<id>/genes')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  WBPhenotype:0000180 (axon morphology variant), MP:0001569 (abnormal circulating bilirubin level), '})
 class PhenotypeGeneAssociations(Resource):
 
@@ -714,7 +681,6 @@ class PhenotypeGeneAssociations(Resource):
         )
 
 
-@ns.route('/phenotype/<id>/gene/<taxid>/ids')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  MP:0001569 (abnormal circulating bilirubin level)'})
 @api.doc(params={'taxid': 'Species or high level taxon grouping, e.g  NCBITaxon:10090 (Mus musculus)'})
 class PhenotypeGeneByTaxonAssociations(Resource):
@@ -735,7 +701,6 @@ class PhenotypeGeneByTaxonAssociations(Resource):
             user_agent=USER_AGENT
         )
 
-@ns.route('/phenotype/<id>/genotypes')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  WBPhenotype:0000180 (axon morphology variant), MP:0001569 (abnormal circulating bilirubin level)'})
 class PhenotypeGenotypeAssociations(Resource):
 
@@ -755,7 +720,6 @@ class PhenotypeGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/phenotype/<id>/literature')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  WBPhenotype:0000180 (axon morphology variant), MP:0001569 (abnormal circulating bilirubin level)'})
 class PhenotypeLieratureAssociations(Resource):
 
@@ -775,7 +739,6 @@ class PhenotypeLieratureAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/phenotype/<id>/pathways')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  MP:0001569 (abnormal circulating bilirubin level)'})
 class PhenotypePathwayAssociations(Resource):
 
@@ -795,7 +758,6 @@ class PhenotypePathwayAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/phenotype/<id>/variants')
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  WBPhenotype:0000180 (axon morphology variant), MP:0001569 (abnormal circulating bilirubin level)'})
 class PhenotypeVariantAssociations(Resource):
 
@@ -816,7 +778,6 @@ class PhenotypeVariantAssociations(Resource):
         )
 
 @api.deprecated
-@ns.route('/goterm/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0044598'})
 class GotermGeneAssociations(Resource):
 
@@ -855,7 +816,6 @@ class GotermGeneAssociations(Resource):
                 **args)
 
 
-@ns.route('/function/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0044598'})
 class FunctionGeneAssociations(Resource):
 
@@ -894,7 +854,6 @@ class FunctionGeneAssociations(Resource):
                 **args)
 
 
-@ns.route('/function/<id>')
 @api.doc(params={'id': 'CURIE identifier of a function term (e.g. GO:0044598)'})
 class FunctionAssociations(Resource):
 
@@ -934,7 +893,6 @@ class FunctionAssociations(Resource):
         return data
 
 
-@ns.route('/function/<id>/taxons')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0044598'})
 class FunctionTaxonAssociations(Resource):
 
@@ -973,7 +931,6 @@ class FunctionTaxonAssociations(Resource):
         return data
 
 
-@ns.route('/function/<id>/literature')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0044598'})
 class FunctionLiteratureAssociations(Resource):
 
@@ -1018,7 +975,6 @@ class FunctionLiteratureAssociations(Resource):
 
 
 
-@ns.route('/pathway/<id>/genes')
 @api.doc(params={'id': 'CURIE any pathway element. E.g. REACT:R-HSA-5387390'})
 class PathwayGeneAssociations(Resource):
 
@@ -1037,7 +993,6 @@ class PathwayGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/anatomy/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of anatomical entity, e.g. GO:0005634 (nucleus), UBERON:0002037 (cerebellum), CL:0000540 (neuron). Equivalent IDs can be used with same results'})
 class AnatomyGeneAssociations(Resource):
 
@@ -1047,7 +1002,7 @@ class AnatomyGeneAssociations(Resource):
         """
         Returns genes associated with a given anatomy
         """
-
+        print("ARGS: {}".format(core_parser.parse_args))
         return search_associations(
             subject_category='gene',
             object_category='anatomical entity',
@@ -1056,7 +1011,6 @@ class AnatomyGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/anatomy/<id>/genes/<taxid>')
 @api.doc(params={'id': 'CURIE identifier of anatomical entity, e.g. GO:0005634 (nucleus), UBERON:0002037 (cerebellum), CL:0000540 (neuron). Equivalent IDs can be used with same results'})
 @api.doc(params={'taxid': 'Species or high level taxon grouping, e.g  NCBITaxon:10090 (Mus musculus)'})
 class AnatomyGeneByTaxonAssociations(Resource):
@@ -1079,7 +1033,6 @@ class AnatomyGeneByTaxonAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/substance/<id>/roles')
 @api.doc(params={'id': 'CURIE identifier of substance, e.g. CHEBI:40036'})
 class SubstanceRoleAssociations(Resource):
 
@@ -1093,7 +1046,6 @@ class SubstanceRoleAssociations(Resource):
         """
         return scigraph.substance_to_role_associations(id)
 
-@ns.route('/substance/<id>/participant_in')
 @api.doc(params={'id': 'CURIE identifier of substance, e.g. CHEBI:40036'})
 class SubstanceParticipantInAssociations(Resource):
 
@@ -1117,7 +1069,6 @@ class SubstanceParticipantInAssociations(Resource):
         return scigraph.substance_participates_in_associations(id)
 
 
-@ns.route('/substance/<id>/treats')
 @api.doc(params={'id': 'CURIE identifier of substance, e.g. CHEBI:40036'})
 class SubstanceTreatsAssociations(Resource):
 
@@ -1132,7 +1083,6 @@ class SubstanceTreatsAssociations(Resource):
         """
         return condition_to_drug(id)
 
-@ns.route('/genotype/<id>/genotypes')
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-6607'})
 class GenotypeGenotypeAssociations(Resource):
 
@@ -1154,7 +1104,6 @@ class GenotypeGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/genotype/<id>/phenotypes')
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-4286'})
 class GenotypePhenotypeAssociations(Resource):
 
@@ -1173,7 +1122,6 @@ class GenotypePhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/genotype/<id>/diseases')
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. dbSNPIndividual:11441 (if non-human will return models)'})
 class GenotypeDiseaseAssociations(Resource):
 
@@ -1193,7 +1141,6 @@ class GenotypeDiseaseAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/genotype/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-6607'})
 class GenotypeGeneAssociations(Resource):
 
@@ -1215,7 +1162,6 @@ class GenotypeGeneAssociations(Resource):
 
 ##
 
-@ns.route('/variant/<id>/genotypes')
 @api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8'})
 class VariantGenotypeAssociations(Resource):
 
@@ -1235,7 +1181,6 @@ class VariantGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/variant/<id>/phenotypes')
 @api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8, ClinVarVariant:39783'})
 class VariantPhenotypeAssociations(Resource):
 
@@ -1254,7 +1199,6 @@ class VariantPhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/variant/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8, ClinVarVariant:39783'})
 class VariantGeneAssociations(Resource):
 
@@ -1274,7 +1218,6 @@ class VariantGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/diseases')
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. MGI:5573196'})
 class ModelDiseaseAssociations(Resource):
 
@@ -1293,7 +1236,6 @@ class ModelDiseaseAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/genes')
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. MMRRC:042787'})
 class ModelGeneAssociations(Resource):
 
@@ -1312,7 +1254,6 @@ class ModelGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/genotypes')
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. Coriell:NA16660'})
 class ModelGenotypeAssociations(Resource):
 
@@ -1331,7 +1272,6 @@ class ModelGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/literature')
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. MGI:5644542'})
 class ModelLiteratureAssociations(Resource):
 
@@ -1351,7 +1291,6 @@ class ModelLiteratureAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/phenotypes')
 @api.doc(params={'id': 'id'})
 class ModelPhenotypeAssociations(Resource):
 
@@ -1370,7 +1309,6 @@ class ModelPhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@ns.route('/model/<id>/variants')
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. MMRRC:042787'})
 class ModelVariantAssociations(Resource):
 

--- a/biolink/api/cam/endpoints/cam_endpoint.py
+++ b/biolink/api/cam/endpoints/cam_endpoint.py
@@ -8,13 +8,10 @@ from causalmodels.lego_sparql_util import lego_query, ModelQuery
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('cam', description='Operations on causal activity models (LEGO)')
-
 parser = api.parser()
 parser.add_argument('title', help='string to search for in title of model')
 parser.add_argument('contributor', help='string to search for in contributor of model')
 
-@ns.route('/model/')
 class ModelCollection(Resource):
 
     #@api.expect(parser)
@@ -31,7 +28,6 @@ class ModelCollection(Resource):
         FILTER(?p != json_model:)
         }""", limit=1000)
 
-@ns.route('/model/query/')
 class ModelQuery(Resource):
 
     @api.expect(parser)
@@ -47,7 +43,6 @@ class ModelQuery(Resource):
         sparql = mq.gen_sparql()
         return lego_query(sparql, limit=100)
     
-@ns.route('/model/properties/')
 class ModelProperties(Resource):
 
     @api.expect(parser)
@@ -63,8 +58,7 @@ class ModelProperties(Resource):
         FILTER(?p != json_model:)
         }""", limit=1000)
 
-@ns.route('/model/contributors/')
-class ModelContibutors(Resource):
+class ModelContributors(Resource):
 
     #@api.expect(parser)
     def get(self):
@@ -78,7 +72,6 @@ class ModelContibutors(Resource):
            dc:contributor ?v
         }""", limit=1000)
 
-@ns.route('/instances/')
 class ModelInstances(Resource):
 
     #@api.expect(parser)
@@ -92,7 +85,6 @@ class ModelInstances(Resource):
         {?i rdfs:isDefinedBy ?model 
         }""", limit=1000)
     
-@ns.route('/model/property_values/')
 class ModelPropertyValues(Resource):
 
     @api.expect(parser)
@@ -108,7 +100,6 @@ class ModelPropertyValues(Resource):
         FILTER(?p != json_model:)
         }""", limit=1000)
     
-@ns.route('/model/<id>')
 class ModelObject(Resource):
 
     #@api.expect(parser)
@@ -126,7 +117,6 @@ class ModelObject(Resource):
 
         return []
 
-@ns.route('/instance/<id>')
 class InstanceObject(Resource):
 
     @api.expect(parser)
@@ -142,7 +132,6 @@ class InstanceObject(Resource):
 
         return []
     
-@ns.route('/activity/')
 class ActivityCollection(Resource):
 
     @api.expect(parser)
@@ -159,7 +148,6 @@ class ActivityCollection(Resource):
         }
         """)
     
-@ns.route('/physical_interaction/')
 class PhysicalInteraction(Resource):
 
     @api.expect(parser)

--- a/biolink/api/entityset/endpoints/geneset_homologs.py
+++ b/biolink/api/entityset/endpoints/geneset_homologs.py
@@ -12,12 +12,9 @@ MAX_ROWS=10000
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('bioentityset/homologs', description='Map gene IDs to their homologs')
-
 parser = api.parser()
 parser.add_argument('subject', action='append', help='Entity ids to be examined, e.g. NCBIGene:9342, NCBIGene:7227, NCBIGene:8131, NCBIGene:157570, NCBIGene:51164, NCBIGene:6689, NCBIGene:6387')
 
-@ns.route('/')
 class EntitySetHomologs(Resource):
 
     @api.expect(parser)

--- a/biolink/api/entityset/endpoints/overrepresentation.py
+++ b/biolink/api/entityset/endpoints/overrepresentation.py
@@ -14,8 +14,6 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('bioentityset', description='operations over sets of entities')
-
 parser = api.parser()
 
 parser.add_argument('subject', action='append', help='Entity ids to be examined, e.g. NCBIGene:9342, NCBIGene:7227, NCBIGene:8131, NCBIGene:157570, NCBIGene:51164, NCBIGene:6689, NCBIGene:6387')
@@ -26,7 +24,6 @@ parser.add_argument('max_p_value', default='0.05', help='Exclude results with p-
 parser.add_argument('ontology', help='ontology id. Must be obo id. Examples: go, mp, hp, uberon (optional: will be inferred if left blank)')
 parser.add_argument('taxon', help='must be NCBITaxon CURIE. Example: NCBITaxon:9606')
 
-@ns.route('/overrepresentation/')
 @api.doc(params={'object_category': 'CATEGORY of entity at link OBJECT (target), e.g. function, phenotype, disease'})
 class OverRepresentation(Resource):
 

--- a/biolink/api/entityset/endpoints/slimmer.py
+++ b/biolink/api/entityset/endpoints/slimmer.py
@@ -11,8 +11,6 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('bioentityset/slimmer', description='maps a set of entities to a slim')
-
 INVOLVED_IN = 'involved_in'
 ACTS_UPSTREAM_OF_OR_WITHIN = 'acts_upstream_of_or_within'
 
@@ -27,7 +25,6 @@ parser.add_argument('exclude_automatic_assertions', type=inputs.boolean, default
 parser.add_argument('rows', type=int, required=False, default=100, help='number of rows')
 parser.add_argument('start', type=int, required=False, help='beginning row')
 
-@ns.route('/function')
 @api.param('relationship_type', "relationship type ('{}' or '{}')".format(INVOLVED_IN, ACTS_UPSTREAM_OF_OR_WITHIN), enum=[INVOLVED_IN, ACTS_UPSTREAM_OF_OR_WITHIN], default=ACTS_UPSTREAM_OF_OR_WITHIN)
 class EntitySetFunctionSlimmer(Resource):
 
@@ -87,7 +84,6 @@ class EntitySetFunctionSlimmer(Resource):
 
         return results
 
-@ns.route('/anatomy')
 class EntitySetAnatomySlimmer(Resource):
 
     @api.expect(parser)
@@ -111,7 +107,6 @@ class EntitySetAnatomySlimmer(Resource):
         )
         return results
 
-@ns.route('/phenotype')
 class EntitySetPhenotypeSlimmer(Resource):
 
     @api.expect(parser)

--- a/biolink/api/entityset/endpoints/summary.py
+++ b/biolink/api/entityset/endpoints/summary.py
@@ -12,8 +12,6 @@ MAX_ROWS=10000
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('bioentityset', description='operations over sets of entities')
-
 parser = api.parser()
 
 parser.add_argument('subject', action='append', help='Entity ids to be examined, e.g. NCBIGene:9342, NCBIGene:7227, NCBIGene:8131, NCBIGene:157570, NCBIGene:51164, NCBIGene:6689, NCBIGene:6387')
@@ -21,7 +19,6 @@ parser.add_argument('background', action='append', help='Entity ids in backgroun
 parser.add_argument('object_category', help='E.g. phenotype, function')
 parser.add_argument('object_slim', help='Slim or subset to which the descriptors are to be mapped, NOT IMPLEMENTED')
 
-@ns.route('/descriptor/counts/')
 class EntitySetSummary(Resource):
 
     @api.expect(parser)
@@ -46,8 +43,6 @@ class EntitySetSummary(Resource):
         del results['facet_counts'][M.OBJECT_CLOSURE]
         return {'results':obj_count_dict, 'facets': results['facet_counts']}
 
-    
-@ns.route('/associations/')
 class EntitySetAssociations(Resource):
 
     @api.expect(parser)
@@ -96,8 +91,6 @@ class EntitySetAssociations(Resource):
 #        return results
     
 
-    
-@ns.route('/graph/')
 class EntitySetGraphResource(Resource):
 
     @api.expect(parser)

--- a/biolink/api/evidence/endpoints/graph.py
+++ b/biolink/api/evidence/endpoints/graph.py
@@ -15,12 +15,9 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('evidence/graph', description='Operations on evidence graphs')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<id>')
 @api.doc(params={'id': 'association id, e.g. cfef92b7-bfa3-44c2-a537-579078d2de37'})
 class EvidenceGraphObject(Resource):
 
@@ -42,7 +39,6 @@ class EvidenceGraphObject(Resource):
         eg = assoc.get('evidence_graph')
         return [eg]
 
-@ns.route('/<id>/image')
 @api.doc(params={'id': 'association id, e.g. cfef92b7-bfa3-44c2-a537-579078d2de37'})
 class EvidenceGraphImage(Resource):
 

--- a/biolink/api/genome/endpoints/region.py
+++ b/biolink/api/genome/endpoints/region.py
@@ -8,11 +8,8 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('genome/features/', description='Operations to retrieve sequence features')
-
 parser = api.parser()
 
-@ns.route('/within/<build>/<reference>/<begin>/<end>')
 class FeaturesWithinResource(Resource):
 
     

--- a/biolink/api/graph/endpoints/node.py
+++ b/biolink/api/graph/endpoints/node.py
@@ -8,12 +8,9 @@ from biolink.api.restplus import api
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('graph', description='Operations over data graphs')
-
 parser = api.parser()
 sg = SciGraph()
 
-@ns.route('/node/<id>')
 @api.doc(params={'id': 'CURIE e.g. HP:0000465'})
 class NodeResource(Resource):
 
@@ -30,7 +27,6 @@ class NodeResource(Resource):
         
         return sg.graph(id)
 
-@ns.route('/edges/from/<id>')
 @api.doc(params={'id': 'CURIE e.g. HP:0000465'})
 class EdgeResource(Resource):
 

--- a/biolink/api/identifier/endpoints/mapper.py
+++ b/biolink/api/identifier/endpoints/mapper.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('identifier/mapper', description='mapping and resolution of identifiers')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<source>/<target>/')
 class IdentifierMapper(Resource):
 
     @api.expect(parser)

--- a/biolink/api/identifier/endpoints/prefixes.py
+++ b/biolink/api/identifier/endpoints/prefixes.py
@@ -8,11 +8,8 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('identifier/prefixes', description='identifier prefixes')
-
 parser = api.parser()
 
-@ns.route('/')
 class PrefixCollection(Resource):
 
     @api.expect(parser)
@@ -22,7 +19,6 @@ class PrefixCollection(Resource):
         """
         return get_prefixes()
 
-@ns.route('/expand/<id>')
 @api.doc(params={'id': 'ID of entity to be contracted to URI, e.g "MGI:1"'})
 class PrefixExpand(Resource):
 
@@ -33,7 +29,6 @@ class PrefixExpand(Resource):
         """
         return expand_uri(id)
 
-@ns.route('/contract/<path:uri>')
 @api.doc(params={'uri': 'URI of entity to be contracted to identifier/CURIE, e.g "http://www.informatics.jax.org/accession/MGI:1"'})
 class PrefixContract(Resource):
 

--- a/biolink/api/image/endpoints/images.py
+++ b/biolink/api/image/endpoints/images.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('image/images', description='foo bar')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<term>')
 class Foo(Resource):
 
     @api.expect(parser)

--- a/biolink/api/link/endpoints/associations_from.py
+++ b/biolink/api/link/endpoints/associations_from.py
@@ -10,8 +10,6 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('association', description='Retrieve associations between entities')
-
 parser = api.parser()
 parser.add_argument('subject_category', help='Category of entity at link Subject (source), e.g. gene, disease, phenotype')
 parser.add_argument('object_category', help='Category of entity at link Object (target), e.g. gene, disease, phenotype')
@@ -26,7 +24,6 @@ parser.add_argument('map_identifiers', help='Prefix to map all IDs to, e.g. NCBI
 parser.add_argument('slim', action='append', help='Map objects up (slim) to a higher level category. Value can be ontology class ID or subset ID')
 parser.add_argument('use_compact_associations', type=inputs.boolean, default=False, help='If true, returns results in compact associations format')
 
-@ns.route('/from/<subject>')
 @api.doc(params={'subject': 'Return associations emanating from this node, e.g. NCBIGene:84570, ZFIN:ZDB-GENE-050417-357 (If ID is from an ontology then results would include inferred associations, by default)'})
 class AssociationsFrom(Resource):
 
@@ -40,7 +37,6 @@ class AssociationsFrom(Resource):
 
         return search_associations(subject=subject, user_agent=USER_AGENT, **args)
 
-@ns.route('/to/<object>')
 @api.doc(params={'object': 'Return associations pointing to this node, e.g. specifying MP:0013765 will return all genes, variants, strains, etc. annotated with this term. Can also be a biological entity such as a gene'})
 class AssociationsTo(Resource):
 
@@ -54,7 +50,6 @@ class AssociationsTo(Resource):
 
         return search_associations(object=object, user_agent=USER_AGENT, **args)
 
-@ns.route('/between/<subject>/<object>')
 @api.doc(params={'subject': 'Return associations emanating from this node, e.g. MGI:1342287 (If ID is from an ontology then results would include inferred associations, by default)'})
 @api.doc(params={'object': 'Return associations pointing to this node, e.g. MP:0013765. Can also be a biological entity such as a gene'})
 class AssociationsBetween(Resource):

--- a/biolink/api/link/endpoints/find_associations.py
+++ b/biolink/api/link/endpoints/find_associations.py
@@ -12,8 +12,6 @@ log = logging.getLogger(__name__)
 
 M=GolrFields()
 
-ns = api.namespace('association', description='Associations between entities or entity and descriptors')
-
 parser = api.parser()
 parser.add_argument('subject', help='Return associations emanating from this node, e.g. NCBIGene:84570, ZFIN:ZDB-GENE-050417-357 (If ID is from an ontology then results would include inferred associations, by default)')
 parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
@@ -26,7 +24,6 @@ parser.add_argument('start', type=int, required=False, default=0, help='beginnin
 parser.add_argument('rows', type=int, required=False, default=10, help='number of rows')
 parser.add_argument('map_identifiers', help='Prefix to map all IDs to, e.g. NCBIGene')
 
-@ns.route('/<id>')
 @api.doc(params={'id': 'identifier for an association, e.g. f5ba436c-f851-41b3-9d9d-bb2b5fc879d4'}, required=True)
 class AssociationObject(Resource):
 
@@ -43,8 +40,6 @@ class AssociationObject(Resource):
 
         return get_association(id, user_agent=USER_AGENT)
 
-
-@ns.route('/find')
 class AssociationSearch(Resource):
 
     @api.expect(parser)
@@ -57,7 +52,6 @@ class AssociationSearch(Resource):
 
         return search_associations(user_agent=USER_AGENT, **args)
 
-@ns.route('/find/<subject_category>')
 @api.doc(params={'subject_category': 'Category of entity at link Subject (source), e.g. gene, disease, phenotype'}, required=True)
 class AssociationBySubjectCategorySearch(Resource):
 
@@ -71,7 +65,6 @@ class AssociationBySubjectCategorySearch(Resource):
 
         return search_associations(subject_category=subject_category, user_agent=USER_AGENT, **args)
 
-@ns.route('/find/<subject_category>/<object_category>')
 @api.doc(params={'subject_category': 'Category of entity at link Subject (source), e.g. gene, disease, phenotype'})
 @api.doc(params={'object_category': 'Category of entity at link Object (target), e.g. gene, disease, phenotype'})
 class AssociationBySubjectAndObjectCategorySearch(Resource):

--- a/biolink/api/mart/endpoints/mart.py
+++ b/biolink/api/mart/endpoints/mart.py
@@ -29,12 +29,9 @@ limiter = Limiter(
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('mart', description='Bulk operations')
-
 parser = api.parser()
 parser.add_argument('slim', action='append', help='Map objects up (slim) to a higher level category. Value can be ontology class ID or subset ID')
 
-@ns.route('/gene/<object_category>/<taxon>')
 #@limiter.limit("1 per minute")
 @api.doc(params={'object_category': 'Category of entity at link Object (target), e.g. phenotype, disease'})
 @api.doc(params={'taxon': 'taxon of gene, must be of form NCBITaxon:9606'})
@@ -56,7 +53,6 @@ class MartGeneAssociationsResource(Resource):
         )
         return assocs
 
-@ns.route('/case/<object_category>/<taxon>')
 #@limiter.limit("1 per minute")
 @api.doc(params={'object_category': 'Category of entity at link Subject (target), e.g. phenotype, disease'})
 @api.doc(params={'taxon': 'taxon of case, must be of form NCBITaxon:9606'})
@@ -83,7 +79,6 @@ class MartCaseAssociationsResource(Resource):
         )
         return assocs
 
-@ns.route('/disease/<object_category>/<taxon>')
 #@limiter.limit("1 per minute")
 @api.doc(params={'object_category': 'Category of entity at link Object (target), e.g. phenotype, disease'})
 @api.doc(params={'taxon': 'taxon of disease, must be of form NCBITaxon:9606'})
@@ -110,7 +105,6 @@ class MartDiseaseAssociationsResource(Resource):
         )
         return assocs
 
-@ns.route('/paralog/<taxon1>/<taxon2>')
 @api.doc(params={'taxon1': 'subject taxon, e.g. NCBITaxon:9606'})
 @api.doc(params={'taxon2': 'object taxon, e.g. NCBITaxon:9606'})
 class MartParalogAssociationsResource(Resource):
@@ -129,7 +123,6 @@ class MartParalogAssociationsResource(Resource):
         )
         return assocs
 
-@ns.route('/ortholog/<taxon1>/<taxon2>')
 @api.doc(params={'taxon1': 'subject taxon, e.g. NCBITaxon:9606'})
 @api.doc(params={'taxon2': 'object taxon, e.g. NCBITaxon:10090'})
 class MartOrthologAssociationsResource(Resource):

--- a/biolink/api/nlp/endpoints/annotate.py
+++ b/biolink/api/nlp/endpoints/annotate.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('nlp/annotate', description='annotate text using named entities')
-
 parser = api.parser()
 parser.add_argument('category', action='append', help='E.g. phenotype')
 
-@ns.route('/<text>')
 class Annotate(Resource):
 
     @api.expect(parser)

--- a/biolink/api/ontol/endpoints/enrichment.py
+++ b/biolink/api/ontol/endpoints/enrichment.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontol/enrichment', description='foo bar')
-
 parser = api.parser()
 parser.add_argument('bioentity_ids', help='List of ids')
 
-@ns.route('/')
 class Foo(Resource):
 
     @api.expect(parser)

--- a/biolink/api/ontol/endpoints/labeler.py
+++ b/biolink/api/ontol/endpoints/labeler.py
@@ -9,12 +9,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontol/labeler', description='Assigns labels to ids')
-
 parser = api.parser()
 parser.add_argument('id', action='append', help='List of ids')
 
-@ns.route('/')
 class OntolLabelerResource(Resource):
 
     @api.expect(parser)

--- a/biolink/api/ontol/endpoints/ontology_endpoint.py
+++ b/biolink/api/ontol/endpoints/ontology_endpoint.py
@@ -46,9 +46,6 @@ subgraph_params.add_argument('include_meta', type=inputs.boolean, default=False,
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontology', description='Operations on Ontology Terms and Subsets')
-
-@ns.route('/term/<id>')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0003677'})
 class OntologyTerm(Resource):
 
@@ -60,8 +57,6 @@ class OntologyTerm(Resource):
         results = run_sparql_on(query, EOntology.GO)
         return transform(results[0], ['synonyms', 'relatedSynonyms', 'alternativeIds', 'xrefs', 'subsets'])
 
-
-@ns.route('/term/<id>/graph')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0000981'})
 class OntologyTermGraph(Resource):
 
@@ -103,7 +98,6 @@ class OntologyTermGraph(Resource):
 
 #         return None
 
-@ns.route('/term/<id>/subgraph')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0007275'})
 class OntologyTermSubgraph(Resource):
 
@@ -132,8 +126,6 @@ class OntologyTermSubgraph(Resource):
         json_obj = ojr.to_json(subont, include_meta=args.include_meta)
         return json_obj
 
-
-@ns.route('/term/<id>/subsets')
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0006259'})
 class OntologyTermSubsets(Resource):
 
@@ -147,7 +139,6 @@ class OntologyTermSubsets(Resource):
         results = replace(results, "subset", "OBO:go#", "")
         return results
 
-@ns.route('/subset/<id>')
 @api.doc(params={'id': 'name of a slim subset, e.g. goslim_agr, goslim_generic'})
 class OntologySubset(Resource):
 
@@ -204,7 +195,6 @@ class OntologySubset(Resource):
 #         """
 #         return None
 
-@ns.route('/shared/<subject>/<object>')
 @api.doc(params={'subject': 'CURIE identifier of a GO term, e.g. GO:0006259',
                  'object': 'CURIE identifier of a GO term, e.g. GO:0046483' })
 class OntologyTermsSharedAncestor(Resource):

--- a/biolink/api/ontol/endpoints/slimmer.py
+++ b/biolink/api/ontol/endpoints/slimmer.py
@@ -12,12 +12,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontol/slimmer', description='Mapping to an ontology subset')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<subset>')
 class MapToSlimResource(Resource):
 
 

--- a/biolink/api/ontol/endpoints/subgraph.py
+++ b/biolink/api/ontol/endpoints/subgraph.py
@@ -12,8 +12,6 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontol', description='extract a subgraph from an ontology')
-
 parser = api.parser()
 parser.add_argument('cnode', action='append', help='Additional classes')
 parser.add_argument('include_ancestors', type=inputs.boolean, default=True, help='Include Ancestors')
@@ -21,7 +19,6 @@ parser.add_argument('include_descendants', type=inputs.boolean, help='Include De
 parser.add_argument('relation', action='append', default=['subClassOf', 'BFO:0000050'], help='Additional classes')
 parser.add_argument('include_meta', type=inputs.boolean, default=False, help='Include metadata in response')
 
-@ns.route('/subgraph/<ontology>/<node>')
 @api.doc(params={'ontology': 'ontology ID, e.g. go, uberon, mp, hp'})
 @api.doc(params={'node': 'class ID, e.g. HP:0001288'})
 class ExtractOntologySubgraphResource(Resource):

--- a/biolink/api/ontol/endpoints/termstats.py
+++ b/biolink/api/ontol/endpoints/termstats.py
@@ -9,14 +9,11 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('ontol', description='ontology operations')
-
 parser = api.parser()
 parser.add_argument('evidence', help="""Object id, e.g. ECO:0000501 (for IEA; Includes inferred by default)
                     or a specific publication or other supporting ibject, e.g. ZFIN:ZDB-PUB-060503-2.
                     """)
 
-@ns.route('/information_content/<subject_category>/<object_category>/<subject_taxon>')
 class InformationContentResource(Resource):
 
     @api.expect(parser)

--- a/biolink/api/owl/endpoints/ontology.py
+++ b/biolink/api/owl/endpoints/ontology.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('owl/ontology', description='OWL-level operations on an ontology')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/dlquery/<query>')
 class DLQuery(Resource):
 
     @api.expect(parser)
@@ -29,7 +26,6 @@ class DLQuery(Resource):
 
         return []
 
-@ns.route('/sparql/<query>')
 class SparqlQuery(Resource):
 
     @api.expect(parser)

--- a/biolink/api/pair/endpoints/pairsim.py
+++ b/biolink/api/pair/endpoints/pairsim.py
@@ -8,12 +8,9 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('pair/sim', description='pairwise similarity between two entities')
-
 parser = api.parser()
 parser.add_argument('object_category', help='e.g. disease, phenotype, gene. Two subjects will be compared based on overlap between associations to objects in this category')
 
-@ns.route('/jaccard/<id1>/<id2>/')
 @api.doc(params={'id1': 'id, e.g. NCBIGene:10891; ZFIN:ZDB-GENE-980526-166; UniProtKB:Q15465'})
 @api.doc(params={'id2': 'id, e.g. NCBIGene:1200; ZFIN:ZDB-GENE-980528-2059; UniProtKB:P12644'})
 class PairSimJaccardResource(Resource):

--- a/biolink/api/patient/endpoints/individual.py
+++ b/biolink/api/patient/endpoints/individual.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('individual', description='Individual humans (including patients), or organisms')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<id>')
 class Individual(Resource):
 
     @api.expect(parser)
@@ -29,7 +26,6 @@ class Individual(Resource):
 
         return []
 
-@ns.route('/pedigree/<id>')
 class Pedigree(Resource):
 
     @api.expect(parser)

--- a/biolink/api/pub/endpoints/pubs.py
+++ b/biolink/api/pub/endpoints/pubs.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('pub/pubs', description='Operations on publication/literature')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<term>')
 class Foo(Resource):
 
     @api.expect(parser)

--- a/biolink/api/refine/endpoints/reconcile.py
+++ b/biolink/api/refine/endpoints/reconcile.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('refine/reconcile', description='foo bar')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<term>')
 class Foo(Resource):
 
     @api.expect(parser)

--- a/biolink/api/relations/endpoints/relation_usage.py
+++ b/biolink/api/relations/endpoints/relation_usage.py
@@ -11,16 +11,12 @@ log = logging.getLogger(__name__)
 
 M=GolrFields()
 
-ns = api.namespace('relation/usage', description='Usage of different relationship types')
-
 parser = api.parser()
 parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 parser.add_argument('evidence', help="""Object id, e.g. ECO:0000501 (for IEA; Includes inferred by default)
                     or a specific publication or other supporting ibject, e.g. ZFIN:ZDB-PUB-060503-2.
                     """)
 
-
-@ns.route('/')
 class RelationUsageResource(Resource):
 
     @api.expect(parser)
@@ -39,7 +35,6 @@ class RelationUsageResource(Resource):
             **args
         )
 
-@ns.route('/between/<subject_category>/<object_category>')
 class RelationUsageBetweenResource(Resource):
 
     @api.expect(parser)
@@ -58,8 +53,7 @@ class RelationUsageBetweenResource(Resource):
             user_agent=USER_AGENT,
             **args
         )
-    
-@ns.route('/pivot/')
+
 class RelationUsagePivotResource(Resource):
 
     @api.expect(parser)
@@ -77,9 +71,7 @@ class RelationUsagePivotResource(Resource):
             user_agent=USER_AGENT,
             **args
         )
-    
-    
-@ns.route('/pivot/label')
+
 class RelationUsagePivotLabelResource(Resource):
 
     @api.expect(parser)

--- a/biolink/api/search/endpoints/entitysearch.py
+++ b/biolink/api/search/endpoints/entitysearch.py
@@ -8,8 +8,6 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('search', description='Search for entities')
-
 def get_simple_parser():
         """
         A simple flaskrest parser object that includes basic http params
@@ -60,7 +58,6 @@ simple_parser = get_simple_parser()
 adv_parser = get_advanced_parser()
 layperson_parser = get_layperson_parser()
 
-@ns.route('/entity/<term>')
 @api.doc(params={'term': 'search string, e.g. shh, parkinson, femur'})
 class SearchEntities(Resource):
 
@@ -75,7 +72,6 @@ class SearchEntities(Resource):
         results = q.search()
         return results
 
-@ns.route('/entity/hpo-pl/<term>')
 @api.doc(params={'term': 'search string, e.g. muscle atrophy, frequent infections'})
 class SearchHPOEntities(Resource):
 
@@ -106,8 +102,6 @@ class SearchHPOEntities(Resource):
         results = q.autocomplete()
         return results
 
-
-@ns.route('/entity/autocomplete/<term>')
 class Autocomplete(Resource):
 
     @api.expect(simple_parser)

--- a/biolink/api/variation/endpoints/analyze.py
+++ b/biolink/api/variation/endpoints/analyze.py
@@ -8,12 +8,9 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('variation/analyze', description='foo bar')
-
 parser = api.parser()
 #parser.add_argument('subject_taxon', help='SUBJECT TAXON id, e.g. NCBITaxon:9606. Includes inferred by default')
 
-@ns.route('/<term>')
 class Analyze(Resource):
 
     @api.expect(parser)

--- a/biolink/api/variation/endpoints/variantset.py
+++ b/biolink/api/variation/endpoints/variantset.py
@@ -11,8 +11,6 @@ import pysolr
 
 log = logging.getLogger(__name__)
 
-ns = api.namespace('variation/set', description='Operations related to sets of variants')
-
 pagination_arguments = reqparse.RequestParser()
 pagination_arguments.add_argument('page', type=int, required=False, default=1, help='Page number')
 pagination_arguments.add_argument('per_page', type=int, required=False, choices=[2, 10, 20, 30, 40, 50],
@@ -41,8 +39,6 @@ page_of_variantsets = api.inherit('Page of variant sets', pagination, {
     'items': fields.List(fields.Nested(variantset))
 })
 
-
-@ns.route('/')
 class VariantSetsCollection(Resource):
 
     @api.expect(pagination_arguments)
@@ -68,8 +64,6 @@ class VariantSetsCollection(Resource):
         create_variantset(request.json)
         return None, 201
 
-
-@ns.route('/<id>')
 @api.response(404, 'VariantSet not found.')
 class VariantSetItem(Resource):
 
@@ -98,10 +92,6 @@ class VariantSetItem(Resource):
         delete_post(id)
         return None, 204
 
-
-#@ns.route('/archive/<int:year>/')
-#@ns.route('/archive/<int:year>/<int:month>/')
-@ns.route('/archive/<int:year>/<int:month>/<int:day>/')
 class VariantSetsArchiveCollection(Resource):
 
     @api.expect(pagination_arguments, validate=True)
@@ -126,7 +116,6 @@ class VariantSetsArchiveCollection(Resource):
 
         return posts_page
 
-@ns.route('/analyze/<id>')
 class VariantAnalyze(Resource):
 
     #@api.expect(parser)

--- a/biolink/app.py
+++ b/biolink/app.py
@@ -6,45 +6,6 @@ from flask import Flask, Blueprint, request
 from flask import render_template
 from flask_cors import CORS, cross_origin
 from biolink import settings
-from biolink.api.bio.endpoints.bioentity import ns as bio_objects_namespace
-from biolink.api.link.endpoints.associations_from import ns as associations_from_namespace
-from biolink.api.link.endpoints.find_associations import ns as find_associations_namespace
-from biolink.api.search.endpoints.entitysearch import ns as entity_search_namespace
-
-from biolink.api.ontol.endpoints.ontology_endpoint import ns as ontology_endpoint_namespace
-
-from biolink.api.ontol.endpoints.subgraph import ns as ontol_subgraph_namespace
-from biolink.api.ontol.endpoints.termstats import ns as ontol_termstats_namespace
-from biolink.api.ontol.endpoints.labeler import ns as ontol_labeler
-#from biolink.api.ontol.endpoints.enrichment import ns as ontol_enrichment_namespace
-
-from biolink.api.entityset.endpoints.summary import ns as entityset_summary_namespace
-from biolink.api.entityset.endpoints.slimmer import ns as entityset_slimmer_namespace
-from biolink.api.entityset.endpoints.geneset_homologs import ns as geneset_homologs_namespace
-from biolink.api.entityset.endpoints.overrepresentation import ns as overrepresentation
-from biolink.api.nlp.endpoints.annotate import ns as nlp_annotate_namespace
-from biolink.api.graph.endpoints.node import ns as graph_node_namespace
-
-from biolink.api.ontol.endpoints.subgraph import ns as subgraph_namespace
-
-from biolink.api.mart.endpoints.mart import ns as mart_namespace
-
-from biolink.api.cam.endpoints.cam_endpoint import ns as cam_namespace
-from biolink.api.owl.endpoints.ontology import ns as owl_ontology_namespace
-from biolink.api.patient.endpoints.individual import ns as patient_individual_namespace
-from biolink.api.identifier.endpoints.prefixes import ns as identifier_prefixes_namespace
-from biolink.api.identifier.endpoints.mapper import ns as identifier_prefixes_mapper
-
-from biolink.api.genome.endpoints.region import ns as genome_region_namespace
-from biolink.api.pair.endpoints.pairsim import ns as pair_pairsim_namespace
-
-from biolink.api.evidence.endpoints.graph import ns as evidence_graph_namespace
-from biolink.api.relations.endpoints.relation_usage import ns as relation_usage_namespace
-
-from biolink.api.variation.endpoints.variantset import ns as variation_variantset_namespace
-
-from biolink.api.pub.endpoints.pubs import ns as pubs_namespace
-
 
 from biolink.api.restplus import api
 
@@ -72,7 +33,22 @@ app.config['ERROR_404_HELP'] = settings.RESTPLUS_ERROR_404_HELP
 
 blueprint = Blueprint('api', __name__, url_prefix='/api')
 api.init_app(blueprint)
-#api.add_namespace(link_search_namespace)
+
+mapping = settings.get_biolink_config().get('route_mapping')
+
+for ns in mapping['namespace']:
+    namespace = api.namespace(ns['name'], description=ns['description'])
+    routes = ns['routes']
+    for r in routes:
+        route = r['route']
+        resource = r['resource']
+        log.debug("Registering Resource: {} to route: {}".format(resource, route))
+        module_name = '.'.join(resource.split('.')[0:-1])
+        resource_class_name = resource.split('.')[-1]
+        module = __import__(module_name, fromlist=[resource_class_name])
+        resource_class = getattr(module, resource_class_name)
+        namespace.add_resource(resource_class, route)
+
 app.register_blueprint(blueprint)
 db.init_app(app)
 

--- a/biolink/settings.py
+++ b/biolink/settings.py
@@ -1,3 +1,5 @@
+import yaml
+
 # Flask settings
 FLASK_SERVER_NAME = 'localhost:8888'
 FLASK_DEBUG = True  # Do not use debug mode in production
@@ -11,3 +13,13 @@ RESTPLUS_ERROR_404_HELP = False
 # SQLAlchemy settings
 SQLALCHEMY_DATABASE_URI = 'sqlite:///db.sqlite'
 SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+CONFIG = 'conf/config.yaml'
+biolink_config = None
+
+def get_biolink_config():
+    global biolink_config
+    if biolink_config is None:
+        with open(CONFIG, 'r') as f:
+            biolink_config = yaml.load(f)
+    return biolink_config

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -42,121 +42,344 @@ route_mapping:
     - name: bioentity
       description: Retrieval of domain entities plus associations
       routes:
-      - route: /<id>
-        resource: biolink.api.bio.endpoints.bioentity.GenericObject
-      - route: /<type>/<id>
-        resource: biolink.api.bio.endpoints.bioentity.GenericObjectByType
-      - route: /<id>/associations
-        resource: biolink.api.bio.endpoints.bioentity.GenericAssociations
-      - route: /gene/<id>/interactions
-        resource: biolink.api.bio.endpoints.bioentity.GeneInteractions
-      - route: /gene/<id>/homologs
-        resource: biolink.api.bio.endpoints.bioentity.GeneHomologAssociations
-      - route: /gene/<id>/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.GenePhenotypeAssociations
-      - route: /gene/<id>/diseases
-        resource: biolink.api.bio.endpoints.bioentity.GeneDiseaseAssociations
-      - route: /gene/<id>/pathways
-        resource: biolink.api.bio.endpoints.bioentity.GenePathwayAssociations
-      - route: /gene/<id>/expression/anatomy
-        resource: biolink.api.bio.endpoints.bioentity.GeneExpressionAssociations
-      - route: /gene/<id>/anatomy
-        resource: biolink.api.bio.endpoints.bioentity.GeneAnatomyAssociations
-      - route: /gene/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.GeneGenotypeAssociations
-      - route: /gene/<id>/function
-        resource: biolink.api.bio.endpoints.bioentity.GeneFunctionAssociations
-      - route: /gene/<id>/literature
-        resource: biolink.api.bio.endpoints.bioentity.GeneLiteratureAssociations
-      - route: /gene/<id>/models
-        resource: biolink.api.bio.endpoints.bioentity.GeneModelAssociations
-      - route: /gene/<id>/ortholog/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.GeneOrthologPhenotypeAssociations
-      - route: /gene/<id>/ortholog/diseases
-        resource: biolink.api.bio.endpoints.bioentity.GeneOrthologDiseaseAssociations
-      - route: /gene/<id>/variants
-        resource: biolink.api.bio.endpoints.bioentity.GeneVariantAssociations
-      - route: /disease/<id>/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.DiseasePhenotypeAssociations
-      - route: /disease/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseGeneAssociations
-      - route: /disease/<id>/treatment
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseSubstanceAssociations
-      - route: /disease/<id>/models
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
-      - route: /disease/<id>/models/<taxon>
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelTaxonAssociations
-      - route: /disease/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseGenotypeAssociations
-      - route: /disease/<id>/literature
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseLiteratureAssociations
-      - route: /disease/<id>/models
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
-      - route: /disease/<id>/pathways
-        resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
-      - route: /disease/<id>/variants
-        resource: biolink.api.bio.endpoints.bioentity.DiseaseVariantAssociations
-      - route: phenotype/<id>/anatomy
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeAnatomyAssociations
-      - route: /phenotype/<id>/diseases
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeDiseaseAssociations
-      - route: /phenotype/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneAssociations
-      - route: /phenotype/<id>/gene/<taxid>/ids
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneByTaxonAssociations
-      - route: /phenotype/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGenotypeAssociations
-      - route: /phenotype/<id>/literature
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeLieratureAssociations
-      - route: /phenotype/<id>/pathways
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypePathwayAssociations
-      - route: /phenotype/<id>/variants
-        resource: biolink.api.bio.endpoints.bioentity.PhenotypeVariantAssociations
-      - route: /goterm/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.GotermGeneAssociations
-      - route: /function/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.FunctionGeneAssociations
-      - route: /function/<id>
-        resource: biolink.api.bio.endpoints.bioentity.FunctionAssociations
-      - route: /function/<id>/taxons
-        resource: biolink.api.bio.endpoints.bioentity.FunctionTaxonAssociations
-      - route: /function/<id>/literature
-        resource: biolink.api.bio.endpoints.bioentity.FunctionLiteratureAssociations
-      - route: /pathway/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.PathwayGeneAssociations
-      - route: /anatomy/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneAssociations
-      - route: /anatomy/<id>/genes/<taxid>
-        resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneByTaxonAssociations
-      - route: /substance/<id>/roles
-        resource: biolink.api.bio.endpoints.bioentity.SubstanceRoleAssociations
-      - route: /substance/<id>/participant_in
-        resource: biolink.api.bio.endpoints.bioentity.SubstanceParticipantInAssociations
-      - route: /substance/<id>/treats
-        resource: biolink.api.bio.endpoints.bioentity.SubstanceTreatsAssociations
-      - route: /genotype/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.GenotypeGenotypeAssociations
-      - route: /genotype/<id>/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.GenotypePhenotypeAssociations
-      - route: /genotype/<id>/diseases
-        resource: biolink.api.bio.endpoints.bioentity.GenotypeDiseaseAssociations
-      - route: /genotype/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
-      - route: /variant/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
-      - route: /variant/<id>/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
-      - route: /variant/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.VariantGeneAssociations
-      - route: /model/<id>/diseases
-        resource: biolink.api.bio.endpoints.bioentity.ModelDiseaseAssociations
-      - route: /model/<id>/genes
-        resource: biolink.api.bio.endpoints.bioentity.ModelGeneAssociations
-      - route: /model/<id>/genotypes
-        resource: biolink.api.bio.endpoints.bioentity.ModelGenotypeAssociations
-      - route: /model/<id>/literature
-        resource: biolink.api.bio.endpoints.bioentity.ModelLiteratureAssociations
-      - route: /model/<id>/phenotypes
-        resource: biolink.api.bio.endpoints.bioentity.ModelPhenotypeAssociations
-      - route: /model/<id>/variants
-        resource: biolink.api.bio.endpoints.bioentity.ModelVariantAssociations
+        - route: /<id>
+          resource: biolink.api.bio.endpoints.bioentity.GenericObject
+        - route: /<type>/<id>
+          resource: biolink.api.bio.endpoints.bioentity.GenericObjectByType
+        - route: /<id>/associations
+          resource: biolink.api.bio.endpoints.bioentity.GenericAssociations
+        - route: /gene/<id>/interactions
+          resource: biolink.api.bio.endpoints.bioentity.GeneInteractions
+        - route: /gene/<id>/homologs
+          resource: biolink.api.bio.endpoints.bioentity.GeneHomologAssociations
+        - route: /gene/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.GenePhenotypeAssociations
+        - route: /gene/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.GeneDiseaseAssociations
+        - route: /gene/<id>/pathways
+          resource: biolink.api.bio.endpoints.bioentity.GenePathwayAssociations
+        - route: /gene/<id>/expression/anatomy
+          resource: biolink.api.bio.endpoints.bioentity.GeneExpressionAssociations
+        - route: /gene/<id>/anatomy
+          resource: biolink.api.bio.endpoints.bioentity.GeneAnatomyAssociations
+        - route: /gene/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.GeneGenotypeAssociations
+        - route: /gene/<id>/function
+          resource: biolink.api.bio.endpoints.bioentity.GeneFunctionAssociations
+        - route: /gene/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.GeneLiteratureAssociations
+        - route: /gene/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.GeneModelAssociations
+        - route: /gene/<id>/ortholog/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.GeneOrthologPhenotypeAssociations
+        - route: /gene/<id>/ortholog/diseases
+          resource: biolink.api.bio.endpoints.bioentity.GeneOrthologDiseaseAssociations
+        - route: /gene/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.GeneVariantAssociations
+        - route: /disease/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.DiseasePhenotypeAssociations
+        - route: /disease/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseGeneAssociations
+        - route: /disease/<id>/treatment
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseSubstanceAssociations
+        - route: /disease/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
+        - route: /disease/<id>/models/<taxon>
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseModelTaxonAssociations
+        - route: /disease/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseGenotypeAssociations
+        - route: /disease/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseLiteratureAssociations
+        - route: /disease/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
+        - route: /disease/<id>/pathways
+          resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
+        - route: /disease/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.DiseaseVariantAssociations
+        - route: phenotype/<id>/anatomy
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeAnatomyAssociations
+        - route: /phenotype/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeDiseaseAssociations
+        - route: /phenotype/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneAssociations
+        - route: /phenotype/<id>/gene/<taxid>/ids
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneByTaxonAssociations
+        - route: /phenotype/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeGenotypeAssociations
+        - route: /phenotype/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeLieratureAssociations
+        - route: /phenotype/<id>/pathways
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypePathwayAssociations
+        - route: /phenotype/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypeVariantAssociations
+        - route: /goterm/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.GotermGeneAssociations
+        - route: /function/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.FunctionGeneAssociations
+        - route: /function/<id>
+          resource: biolink.api.bio.endpoints.bioentity.FunctionAssociations
+        - route: /function/<id>/taxons
+          resource: biolink.api.bio.endpoints.bioentity.FunctionTaxonAssociations
+        - route: /function/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.FunctionLiteratureAssociations
+        - route: /pathway/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.PathwayGeneAssociations
+        - route: /anatomy/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneAssociations
+        - route: /anatomy/<id>/genes/<taxid>
+          resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneByTaxonAssociations
+        - route: /substance/<id>/roles
+          resource: biolink.api.bio.endpoints.bioentity.SubstanceRoleAssociations
+        - route: /substance/<id>/participant_in
+          resource: biolink.api.bio.endpoints.bioentity.SubstanceParticipantInAssociations
+        - route: /substance/<id>/treats
+          resource: biolink.api.bio.endpoints.bioentity.SubstanceTreatsAssociations
+        - route: /genotype/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeGenotypeAssociations
+        - route: /genotype/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.GenotypePhenotypeAssociations
+        - route: /genotype/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeDiseaseAssociations
+        - route: /genotype/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
+        - route: /variant/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
+        - route: /variant/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
+        - route: /variant/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.VariantGeneAssociations
+        - route: /model/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.ModelDiseaseAssociations
+        - route: /model/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.ModelGeneAssociations
+        - route: /model/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.ModelGenotypeAssociations
+        - route: /model/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.ModelLiteratureAssociations
+        - route: /model/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.ModelPhenotypeAssociations
+        - route: /model/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.ModelVariantAssociations
+    - name: association
+      description: Retrieve associations between entities or entity and descriptors
+      routes:
+        - route: /<id>
+          resource: biolink.api.link.endpoints.find_associations.AssociationObject
+        - route: /find
+          resource: biolink.api.link.endpoints.find_associations.AssociationSearch
+        - route: /find/<subject_category>
+          resource: biolink.api.link.endpoints.find_associations.AssociationBySubjectCategorySearch
+        - route: /find/<subject_category>/<object_category>
+          resource: biolink.api.link.endpoints.find_associations.AssociationBySubjectAndObjectCategorySearch
+        - route: /from/<subject>
+          resource: biolink.api.link.endpoints.associations_from.AssociationsFrom
+        - route: /to/<object>
+          resource: biolink.api.link.endpoints.associations_from.AssociationsTo
+        - route: /between/<subject>/<object>
+          resource: biolink.api.link.endpoints.associations_from.AssociationsBetween
+    - name: cam
+      description: Operations on GO Causal Activity Models (GO-CAMs)
+      routes:
+        - route: /model
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelCollection
+        - route: /model/query
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelQuery
+        - route: /model/properties
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelProperties
+        - route: /model/contributors
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelContributors
+        - route: /instances
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelInstances
+        - route: /model/property_values
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelPropertyValues
+        - route: /model/<id>
+          resource: biolink.api.cam.endpoints.cam_endpoint.ModelObject
+        - route: /instance/<id>
+          resource: biolink.api.cam.endpoints.cam_endpoint.InstanceObject
+        - route: /activity
+          resource: biolink.api.cam.endpoints.cam_endpoint.ActivityCollection
+        - route: /physical_interaction
+          resource: biolink.api.cam.endpoints.cam_endpoint.PhysicalInteraction
+    - name: bioentityset
+      description: Operations over sets of entities
+      routes:
+        - route: /descriptor/counts
+          resource: biolink.api.entityset.endpoints.summary.EntitySetSummary
+        - route: /associations
+          resource: biolink.api.entityset.endpoints.summary.EntitySetAssociations
+        - route: /graph
+          resource: biolink.api.entityset.endpoints.summary.EntitySetGraphResource
+        - route: /overrepresentation
+          resource: biolink.api.entityset.endpoints.overrepresentation.OverRepresentation
+    - name: bioentityset/homologs
+      description: Map gene IDs to their homologs
+      routes:
+        - route: /
+          resource: biolink.api.entityset.endpoints.geneset_homologs.EntitySetHomologs
+    - name: bioentityset/slimmer
+      description: maps a set of entities to a slim
+      routes:
+        - route: /function
+          resource: biolink.api.entityset.endpoints.slimmer.EntitySetFunctionSlimmer
+        - route: /anatomy
+          resource: biolink.api.entityset.endpoints.slimmer.EntitySetAnatomySlimmer
+        - route: /phenotype
+          resource: biolink.api.entityset.endpoints.slimmer.EntitySetPhenotypeSlimmer
+    - name: evidence/graph
+      description: Operations on evidence graphs
+      routes:
+        - route: /<id>
+          resource: biolink.api.evidence.endpoints.graph.EvidenceGraphObject
+        - route: /<id>/image
+          resource: biolink.api.evidence.endpoints.graph.EvidenceGraphImage
+    - name: genome/features
+      description: Operations to retrieve sequence features
+      routes:
+        - route: /within/<build>/<reference>/<begin>/<end>
+          resource: biolink.api.genome.endpoints.region.FeaturesWithinResource
+    - name: graph
+      description: Operations over data graphs
+      routes:
+        - route: /node/<id>
+          resource: biolink.api.graph.endpoints.node.NodeResource
+        - route: /edges/from/<id>
+          resource: biolink.api.graph.endpoints.node.EdgeResource
+    - name: identifier/mapper
+      description: mapping and resolution of identifiers
+      routes:
+        - route: /<source>/<target>/
+          resource: biolink.api.identifier.endpoints.mapper.IdentifierMapper
+    - name: identifier/prefixes
+      description: identifier prefixes
+      routes:
+        - route: /
+          resource: biolink.api.identifier.endpoints.prefixes.PrefixCollection
+        - route: /expand/<id>
+          resource: biolink.api.identifier.endpoints.prefixes.PrefixExpand
+        - route: /contract/<path:uri>
+          resource: biolink.api.identifier.endpoints.prefixes.PrefixContract
+#    - name: images/images
+#      description: To be implemented
+#      routes:
+#        - route: /<term>
+#          resource: biolink.api.image.endpoints.images.Foo
+    - name: mart
+      description: Perform bulk operations
+      routes:
+        - route: /gene/<object_category>/<taxon>
+          resource: biolink.api.mart.endpoints.mart.MartGeneAssociationsResource
+        - route: /case/<object_category>/<taxon>
+          resource: biolink.api.mart.endpoints.mart.MartCaseAssociationsResource
+        - route: /disease/<object_category>/<taxon>
+          resource: biolink.api.mart.endpoints.mart.MartDiseaseAssociationsResource
+        - route: /paralog/<taxon1>/<taxon2>
+          resource: biolink.api.mart.endpoints.mart.MartParalogAssociationsResource
+        - route: /ortholog/<taxon1>/<taxon2>
+          resource: biolink.api.mart.endpoints.mart.MartOrthologAssociationsResource
+    - name: nlp/annotate
+      description: annotate text using named entities
+      routes:
+        - route: /<text>
+          resource: biolink.api.nlp.endpoints.annotate.Annotate
+    - name: ontol
+      description: extract a subgraph from an ontology
+      routes:
+        - route: /subgraph/<ontology>/<node>
+          resource: biolink.api.ontol.endpoints.subgraph.ExtractOntologySubgraphResource
+        - route: /information_content/<subject_category>/<object_category>/<subject_taxon>
+          resource: biolink.api.ontol.endpoints.termstats.InformationContentResource
+#    - name: ontol/slimmer
+#      description: Mapping to an ontology subset
+#      routes:
+#        - route: /<subset>
+#          resource: biolink.api.ontol.endpoints.slimmer.MapToSlimResource
+    - name: ontol/labeler
+      description: Assign labels to IDs
+      routes:
+        - route: /
+          resource: biolink.api.ontol.endpoints.labeler.OntolLabelerResource
+#    - name: ontol/enrichment
+#      description: To be implemented
+#      routes:
+#        - route: /
+#          resource: biolink.api.ontol.endpoints.enrichment.Foo
+    - name: ontology
+      description: Operations on Ontology Terms and Subsets
+      routes:
+        - route: /term/<id>
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologyTerm
+        - route: /term/<id>/graph
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologyTermGraph
+        - route: /term/<id>/subgraph
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologyTermSubgraph
+        - route: /term/<id>/subsets
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologyTermSubsets
+        - route: /subset/<id>
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologySubset
+        - route: /shared/<subject>/<object>
+          resource: biolink.api.ontol.endpoints.ontology_endpoint.OntologyTermsSharedAncestor
+    - name: owl/ontology
+      description: OWL-level operations on an ontology
+      routes:
+        - route: /dlquery/<query>
+          resource: biolink.api.owl.endpoints.ontology.DLQuery
+        - route: /sparql/<query>
+          resource: biolink.api.owl.endpoints.ontology.SparqlQuery
+    - name: pair/sim
+      description: pairwise similarity between two entities
+      routes:
+        - route: /jaccard/<id1>/<id2>
+          resource: biolink.api.pair.endpoints.pairsim.PairSimJaccardResource
+    - name: individual
+      description: Individual humans (including patients), or organisms
+      routes:
+        - route: /<id>
+          resource: biolink.api.patient.endpoints.individual.Individual
+        - route: /pedigree/<id>
+          resource: biolink.api.patient.endpoints.individual.Pedigree
+#    - name: pub/pubs
+#      description: Operations on publication/literature
+#      routes:
+#        - route: /<term>
+#          resource: biolink.api.pub.endpoints.pubs.Foo
+#    - name: refine/reconcile
+#      description: To be implemented
+#      routes:
+#        - route: /<term>
+#          resource: biolink.api.refine.endpoints.reconcile.Foo
+    - name: relation/usage
+      description: Usage of different relationship types
+      routes:
+        - route: /
+          resource: biolink.api.relations.endpoints.relation_usage.RelationUsageResource
+        - route: /between/<subject_category>/<object_category>
+          resource: biolink.api.relations.endpoints.relation_usage.RelationUsageBetweenResource
+        - route: /pivot
+          resource: biolink.api.relations.endpoints.relation_usage.RelationUsagePivotResource
+        - route: /pivot/label
+          resource: biolink.api.relations.endpoints.relation_usage.RelationUsagePivotLabelResource
+    - name: search
+      description: Search for entities
+      routes:
+        - route: /entity/<term>
+          resource: biolink.api.search.endpoints.entitysearch.SearchEntities
+        - route: /entity/hpo-pl/<term>
+          resource: biolink.api.search.endpoints.entitysearch.SearchHPOEntities
+        - route: /entity/autocomplete/<term>
+          resource: biolink.api.search.endpoints.entitysearch.Autocomplete
+#    - name: variation/analyze
+#      description: To be implemented
+#      routes:
+#        - route: /<term>
+#          resource: biolink.api.variation.endpoints.analyze.Analyze
+    - name: variation/set
+      description: Operations related to sets of variants
+      routes:
+         - route: /
+           resource: biolink.api.variation.endpoints.variantset.VariantSetsCollection
+         - route: /<id>
+           resource: biolink.api.variation.endpoints.variantset.VariantSetItem
+         - route: /archive/<int:year>/<int:month>/<int:day>
+           resource: biolink.api.variation.endpoints.variantset.VariantSetsArchiveCollection
+         - route: /analyze/<id>
+           resource: biolink.api.variation.endpoints.variantset.VariantAnalyze

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -37,4 +37,126 @@ ontologies:
   - id: monarch
     handle: data/monarch.json
     pre_load: true
-
+route_mapping:
+  namespace:
+    - name: bioentity
+      description: Retrieval of domain entities plus associations
+      routes:
+      - route: /<id>
+        resource: biolink.api.bio.endpoints.bioentity.GenericObject
+      - route: /<type>/<id>
+        resource: biolink.api.bio.endpoints.bioentity.GenericObjectByType
+      - route: /<id>/associations
+        resource: biolink.api.bio.endpoints.bioentity.GenericAssociations
+      - route: /gene/<id>/interactions
+        resource: biolink.api.bio.endpoints.bioentity.GeneInteractions
+      - route: /gene/<id>/homologs
+        resource: biolink.api.bio.endpoints.bioentity.GeneHomologAssociations
+      - route: /gene/<id>/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.GenePhenotypeAssociations
+      - route: /gene/<id>/diseases
+        resource: biolink.api.bio.endpoints.bioentity.GeneDiseaseAssociations
+      - route: /gene/<id>/pathways
+        resource: biolink.api.bio.endpoints.bioentity.GenePathwayAssociations
+      - route: /gene/<id>/expression/anatomy
+        resource: biolink.api.bio.endpoints.bioentity.GeneExpressionAssociations
+      - route: /gene/<id>/anatomy
+        resource: biolink.api.bio.endpoints.bioentity.GeneAnatomyAssociations
+      - route: /gene/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.GeneGenotypeAssociations
+      - route: /gene/<id>/function
+        resource: biolink.api.bio.endpoints.bioentity.GeneFunctionAssociations
+      - route: /gene/<id>/literature
+        resource: biolink.api.bio.endpoints.bioentity.GeneLiteratureAssociations
+      - route: /gene/<id>/models
+        resource: biolink.api.bio.endpoints.bioentity.GeneModelAssociations
+      - route: /gene/<id>/ortholog/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.GeneOrthologPhenotypeAssociations
+      - route: /gene/<id>/ortholog/diseases
+        resource: biolink.api.bio.endpoints.bioentity.GeneOrthologDiseaseAssociations
+      - route: /gene/<id>/variants
+        resource: biolink.api.bio.endpoints.bioentity.GeneVariantAssociations
+      - route: /disease/<id>/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.DiseasePhenotypeAssociations
+      - route: /disease/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseGeneAssociations
+      - route: /disease/<id>/treatment
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseSubstanceAssociations
+      - route: /disease/<id>/models
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
+      - route: /disease/<id>/models/<taxon>
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelTaxonAssociations
+      - route: /disease/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseGenotypeAssociations
+      - route: /disease/<id>/literature
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseLiteratureAssociations
+      - route: /disease/<id>/models
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
+      - route: /disease/<id>/pathways
+        resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
+      - route: /disease/<id>/variants
+        resource: biolink.api.bio.endpoints.bioentity.DiseaseVariantAssociations
+      - route: phenotype/<id>/anatomy
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeAnatomyAssociations
+      - route: /phenotype/<id>/diseases
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeDiseaseAssociations
+      - route: /phenotype/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneAssociations
+      - route: /phenotype/<id>/gene/<taxid>/ids
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneByTaxonAssociations
+      - route: /phenotype/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeGenotypeAssociations
+      - route: /phenotype/<id>/literature
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeLieratureAssociations
+      - route: /phenotype/<id>/pathways
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypePathwayAssociations
+      - route: /phenotype/<id>/variants
+        resource: biolink.api.bio.endpoints.bioentity.PhenotypeVariantAssociations
+      - route: /goterm/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.GotermGeneAssociations
+      - route: /function/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.FunctionGeneAssociations
+      - route: /function/<id>
+        resource: biolink.api.bio.endpoints.bioentity.FunctionAssociations
+      - route: /function/<id>/taxons
+        resource: biolink.api.bio.endpoints.bioentity.FunctionTaxonAssociations
+      - route: /function/<id>/literature
+        resource: biolink.api.bio.endpoints.bioentity.FunctionLiteratureAssociations
+      - route: /pathway/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.PathwayGeneAssociations
+      - route: /anatomy/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneAssociations
+      - route: /anatomy/<id>/genes/<taxid>
+        resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneByTaxonAssociations
+      - route: /substance/<id>/roles
+        resource: biolink.api.bio.endpoints.bioentity.SubstanceRoleAssociations
+      - route: /substance/<id>/participant_in
+        resource: biolink.api.bio.endpoints.bioentity.SubstanceParticipantInAssociations
+      - route: /substance/<id>/treats
+        resource: biolink.api.bio.endpoints.bioentity.SubstanceTreatsAssociations
+      - route: /genotype/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.GenotypeGenotypeAssociations
+      - route: /genotype/<id>/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.GenotypePhenotypeAssociations
+      - route: /genotype/<id>/diseases
+        resource: biolink.api.bio.endpoints.bioentity.GenotypeDiseaseAssociations
+      - route: /genotype/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
+      - route: /variant/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
+      - route: /variant/<id>/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
+      - route: /variant/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.VariantGeneAssociations
+      - route: /model/<id>/diseases
+        resource: biolink.api.bio.endpoints.bioentity.ModelDiseaseAssociations
+      - route: /model/<id>/genes
+        resource: biolink.api.bio.endpoints.bioentity.ModelGeneAssociations
+      - route: /model/<id>/genotypes
+        resource: biolink.api.bio.endpoints.bioentity.ModelGenotypeAssociations
+      - route: /model/<id>/literature
+        resource: biolink.api.bio.endpoints.bioentity.ModelLiteratureAssociations
+      - route: /model/<id>/phenotypes
+        resource: biolink.api.bio.endpoints.bioentity.ModelPhenotypeAssociations
+      - route: /model/<id>/variants
+        resource: biolink.api.bio.endpoints.bioentity.ModelVariantAssociations


### PR DESCRIPTION
This approach is more `config.yaml` driven.

```yaml
route_mapping:
  namespace:
    - name: bioentity
      description: Retrieval of domain entities plus associations
      routes:
      - route: /<id>
        resource: biolink.api.bio.endpoints.bioentity.GenericObject
      - route: /<type>/<id>
        resource: biolink.api.bio.endpoints.bioentity.GenericObjectByType
      - route: /<id>/associations
        resource: biolink.api.bio.endpoints.bioentity.GenericAssociations
     ...
```

The `config.yaml` allows for a more fine-grained configuration where you define what route maps to which resource.
Having all the routing configuration in one place makes it easier than editing all individual endpoints.

If there is an implementation specific resource then all one has to do is change the route to resource mapping in `config.yaml` and it should be registered during app initialization. 

To remove a route from showing up, simply omit it from the config.

I would prefer this approach over https://github.com/biolink/biolink-api/pull/236

If this looks good then I can go ahead and include all the other routes (currently the `config.yaml` has routes only from `bioentity` namespace).

