### PR TITLE
Preload ontologies

### DIFF
--- a/biolink/app.py
+++ b/biolink/app.py
@@ -6,6 +6,7 @@ from flask import Flask, Blueprint, request
 from flask import render_template
 from flask_cors import CORS, cross_origin
 from biolink import settings
+from biolink.ontology.ontology_manager import get_ontology
 
 from biolink.api.restplus import api
 
@@ -52,11 +53,13 @@ for ns in mapping['namespace']:
 app.register_blueprint(blueprint)
 db.init_app(app)
 
-# initial setup
-#from ontobio.ontol_factory import OntologyFactory
-#factory = OntologyFactory()
-#ont = factory.create()
-
+def preload_ontologies():
+    ontologies = settings.get_biolink_config().get('ontologies')
+    for ontology in ontologies:
+        handle = ontology['handle']
+        if ontology['pre_load']:
+            log.info("Loading {}".format(ontology['id']))
+            get_ontology(handle)
 
 @app.route("/")
 def hello():
@@ -64,6 +67,7 @@ def hello():
 
 def main():
     #initialize_app(app)
+    preload_ontologies()
     log.info('>>>>> Starting development server at http://{}/api/ <<<<<'.format(app.config['SERVER_NAME']))
     app.run(debug=settings.FLASK_DEBUG)
 

--- a/biolink/ontology/ontology_manager.py
+++ b/biolink/ontology/ontology_manager.py
@@ -1,26 +1,23 @@
 import logging
 
 from ontobio.ontol_factory import OntologyFactory
-from ontobio.config import get_config
+from biolink.settings import get_biolink_config
 
-cfg = get_config()
+cfg = get_biolink_config()
 omap = {}
 
 def get_ontology(id):
     handle = id
-    print("HANDLE={}".format(handle))
-    for c in cfg.ontologies:
-        print("ONT={}".format(c))
-        # temporary. TODO fix
-        if not isinstance(c,dict):
-            if c.id == id:
-                handle = c.handle
-                print("Using handle={} for {}".format(handle, id))
+    for c in cfg['ontologies']:
+        if c['id'] == id:
+            logging.info("getting handle for id: {} from cfg".format(id))
+            handle = c['handle']
 
     if handle not in omap:
-        print("Creating a new ontology object for {}".format(handle))
-        omap[handle] = OntologyFactory().create(handle)
+        logging.info("Creating a new ontology object for {}".format(handle))
+        ofa = OntologyFactory()
+        omap[handle] = ofa.create(handle)
     else:
-        print("Using cached for {}".format(handle))
+        logging.info("Using cached for {}".format(handle))
     return omap[handle]
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -24,22 +24,22 @@ use_amigo_for:
 ontologies:
   - id: go
     handle: go
-    pre_load: true
+    pre_load: false
   - id: hp
     handle: hp
-    pre_load: true
+    pre_load: false
 #  - id: mp
 #    handle: mp
-#    pre_load: true
+#    pre_load: false
   - id: uberon
     handle: uberon
-    pre_load: true
+    pre_load: false
   - id: mondo
     handle: mondo
     pre_load: true
 #  - id: monarch
 #    handle: data/monarch.json
-#    pre_load: true
+#    pre_load: false
 route_mapping:
   namespace:
     - name: bioentity

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -28,15 +28,18 @@ ontologies:
   - id: hp
     handle: hp
     pre_load: true
-  - id: mp
-    handle: mp
-    pre_load: true
+#  - id: mp
+#    handle: mp
+#    pre_load: true
   - id: uberon
     handle: uberon
     pre_load: true
-  - id: monarch
-    handle: data/monarch.json
+  - id: mondo
+    handle: mondo
     pre_load: true
+#  - id: monarch
+#    handle: data/monarch.json
+#    pre_load: true
 route_mapping:
   namespace:
     - name: bioentity


### PR DESCRIPTION
This PR adds the ability to preload ontologies, as defined in `config.yaml`.

**Note:** I had to comment out 'mp' from the `config.yaml` due to errors encountered in ontobio (`RecursionError: maximum recursion depth exceeded while calling a Python object`) while trying to load MP ontology.