### PR TITLE
Improve /bioentityset/homologs/ 

### DIFF
--- a/biolink/api/entityset/endpoints/geneset_homologs.py
+++ b/biolink/api/entityset/endpoints/geneset_homologs.py
@@ -2,8 +2,9 @@ import logging
 
 from flask import request
 from flask_restplus import Resource
-from biolink.datamodel.serializers import compact_association_set, association_results
+from biolink.datamodel.serializers import association_results
 from ontobio.golr.golr_associations import search_associations, GolrFields
+from ontobio.vocabulary.relations import HomologyTypes
 
 from biolink.api.restplus import api
 from biolink import USER_AGENT
@@ -12,26 +13,38 @@ MAX_ROWS=10000
 
 log = logging.getLogger(__name__)
 
+homology_types = [
+    HomologyTypes.Homolog.value,
+    HomologyTypes.Paralog.value,
+    HomologyTypes.Ortholog.value,
+    HomologyTypes.LeastDivergedOrtholog.value,
+    HomologyTypes.InParalog.value,
+    HomologyTypes.OutParalog.value,
+    HomologyTypes.Ohnolog.value,
+    HomologyTypes.Xenolog.value
+]
+
 parser = api.parser()
-parser.add_argument('subject', action='append', help='Entity ids to be examined, e.g. NCBIGene:9342, NCBIGene:7227, NCBIGene:8131, NCBIGene:157570, NCBIGene:51164, NCBIGene:6689, NCBIGene:6387')
+parser.add_argument('subject', required=True, action='append', help='Entity ids to be examined, e.g. NCBIGene:9342, NCBIGene:7227, NCBIGene:8131, NCBIGene:157570, NCBIGene:51164, NCBIGene:6689, NCBIGene:6387')
+parser.add_argument('relation', choices=homology_types, help='relation based on which to fetch associations. Default: {} ({})'.format(HomologyTypes.Homolog.value, HomologyTypes.Homolog.name), default=HomologyTypes.Homolog.value)
 
 class EntitySetHomologs(Resource):
 
     @api.expect(parser)
-    @api.marshal_list_with(compact_association_set)
+    @api.marshal_list_with(association_results)
     def get(self):
         """
         Returns homology associations for a given input set of genes
         """
         args = parser.parse_args()
+        subjects = args.get('subject')
+        del args['subject']
 
         M=GolrFields()
-        rel = 'RO:0002434'  # TODO; allow other types
         results = search_associations(
-            subjects=args.get('subject'),
+            subjects=subjects,
             select_fields=[M.SUBJECT, M.RELATION, M.OBJECT],
             use_compact_associations=True,
-            relation=rel,
             rows=MAX_ROWS,
             facet_fields=[],
             user_agent=USER_AGENT,


### PR DESCRIPTION
Improved `/bioentityset/homologs/` to support multiple IDs and get associations based on a given relation. (#232)

@putmantime Feel free to test this out.

The route now takes one (or more) Gene IDs as input as well as a relation. Right now the relation argument is limited one of the following 8 types: 
```
    Ortholog = 'RO:HOM0000017'
    LeastDivergedOrtholog = 'RO:HOM0000020'
    Homolog = 'RO:HOM0000007'
    Paralog = 'RO:HOM0000011'
    InParalog = 'RO:HOM0000023'
    OutParalog = 'RO:HOM0000024'
    Ohnolog = 'RO:HOM0000022'
    Xenolog = 'RO:HOM0000018'
```

 with the default relation being `Homolog`.

Let me know if this needs further refinement.