### PR TITLE
Add inheritance and onset to bioentity/{type}/{id}

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -94,7 +94,7 @@ class GenericObjectByType(Resource):
         """
         Return basic info on an object for a given type
         """
-        obj = scigraph.bioobject(id)
+        obj = scigraph.bioobject(id, type)
         return(obj)
 
 @ns.route('/<id>/associations/')

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -124,7 +124,8 @@ bio_object_core = api.inherit('BioObjectCore', named_object_core, {
 bio_object = api.inherit('BioObject', named_object, {
     'taxon': fields.Nested(taxon, description='Taxon to which the object belongs'),
     'xrefs': fields.List(fields.String, description='Database cross-references. These are usually CURIEs, but may also be URLs. E.g. ENSEMBL:ENSG00000099940 '),
-    
+    'inheritance': fields.List(fields.Nested(named_object_core), description='Inheritance for object'),
+    'clinical_modifiers': fields.List(fields.Nested(named_object_core), description='Clinical modifiers such as age of onset, pace of progression, and temporal patterns'),
 })
 
 # Assoc

--- a/biomodel/core.py
+++ b/biomodel/core.py
@@ -172,7 +172,6 @@ class Node():
                  lbl=None,
                  **kwargs):
         self.id=id
-        self.id=id
         self.lbl=lbl
 
 
@@ -302,7 +301,6 @@ class NamedObject():
                  description=None,
                  **kwargs):
         self.id=id
-        self.id=id
         self.label=label
         self.categories=categories
         self.synonyms=synonyms
@@ -404,7 +402,6 @@ class Taxon():
                  label=None,
                  **kwargs):
         self.id=id
-        self.id=id
         self.label=label
 
 
@@ -435,9 +432,13 @@ class BioObject(NamedObject):
     def __init__(self,
                  id=None,
                  taxon=None,
+                 inheritance=None,
+                 clinical_modifiers=None,
                  **kwargs):
         super(BioObject, self).__init__(id, **kwargs)
-        self.taxon=taxon
+        self.taxon = taxon
+        self.inheritance = inheritance
+        self.clinical_modifiers = clinical_modifiers
 
 
     """
@@ -457,6 +458,10 @@ class BioObject(NamedObject):
             obj.taxon = Taxon.from_json(json_obj['taxon'])
         if 'description' in json_obj:
             obj.description = json_obj['description']
+        if 'inheritance' in json_obj:
+            obj.inheritance = json_obj['inheritance']
+        if 'clinical_modifiers' in json_obj:
+            obj.clinical_modifiers = json_obj['clinical_modifiers']
         return obj
 
 class AnnotationExtension():
@@ -564,7 +569,6 @@ class Association():
                  provided_by=None,
                  publications=None,
                  **kwargs):
-        self.id=id
         self.id=id
         self.type=type
         self.subject=subject

--- a/scigraph/model/BBOPGraph.py
+++ b/scigraph/model/BBOPGraph.py
@@ -84,6 +84,14 @@ class Node:
     def __str__(self):
         return self.id+' "'+str(self.lbl)+'"'
 
+    def as_dict(self):
+        return {
+            "id": self.id,
+            "lbl": self.lbl,
+            "meta": self.meta.pmap
+        }
+
+
 class Edge:
     def __init__(self, obj={}):    
         self.sub = obj['sub']
@@ -101,4 +109,3 @@ class Meta:
         if 'category' in obj:
             self.category_list = obj['category']
         self.pmap = obj
-    

--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -62,7 +62,7 @@ class SciGraph:
         nodes = response.json()['nodes']
         return self.make_NamedObject(**nodes[0])
 
-    def bioobject(self, id, node_type, class_name='BioObject', **params):
+    def bioobject(self, id, node_type=None, class_name='BioObject', **params):
         """
         Get a node in a graph and translates it to biomodels datamodel
 

--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -18,7 +18,8 @@ from biomodel.core import NamedObject, BioObject, SynonymPropertyValue
 HAS_PART = 'http://purl.obolibrary.org/obo/BFO_0000051'
 INHERES_IN = 'http://purl.obolibrary.org/obo/RO_0000052'
 HAS_ROLE = 'http://purl.obolibrary.org/obo/RO_0000087'
-IN_TAXON = 'http://purl.obolibrary.org/obo/RO_0002162'
+IN_TAXON = 'RO:0002162'
+HAS_DISPOSITION = 'RO:0000091'
 ENCODES = 'RO:0002205'
 HAS_DBXREF = 'OIO:hasDbXref'
 
@@ -35,7 +36,7 @@ class SciGraph:
         if url is not None:
             self.url_prefix = url
         else:
-            self.url_prefix = "http://scigraph-ontology.monarchinitiative.org/scigraph/"
+            self.url_prefix = "http://scigraph-data.monarchinitiative.org/scigraph/"
         return
 
     def neighbors(self, id=None, **params):
@@ -59,7 +60,7 @@ class SciGraph:
         nodes = response.json()['nodes']
         return self.make_NamedObject(**nodes[0])
 
-    def bioobject(self, id=None, class_name='BioObject', **params):
+    def bioobject(self, id, node_type, class_name='BioObject', **params):
         """
         Get a node in a graph and translates it to biomodels datamodel
 
@@ -73,29 +74,45 @@ class SciGraph:
 
         Returns: biomodel.BioObject or subclass
         """
-
         response = self.get_response(
             "dynamic/cliqueLeader", q=id, format="json",
             depth=1, **params
         )
 
         nodes = response.json()['nodes']
-        obj = self.make_NamedObject(**nodes[0], class_name=class_name)
+        bio_object = self.make_NamedObject(**nodes[0], class_name=class_name)
 
-        response_for_taxon = self.get_response(
-            "graph/neighbors", q=obj.id, format="json",
-            depth=1, relationshipType=IN_TAXON
+        response = self.get_response(
+            "graph/neighbors", q=bio_object.id, format="json",
+            depth=1, direction="OUTGOING"
         )
+        graph = BBOPGraph(response.json())
 
-        taxon = None
-        for n in response_for_taxon.json()['nodes']:
-            if n['id'] == obj.id:
-                pass
-            else:
-                taxon = self.make_NamedObject(**n)
-        obj.taxon = taxon
+        bio_object.taxon = None
+        taxon_edge = [edge for edge in graph.edges if edge.pred == IN_TAXON]
+        for tax_edge in taxon_edge:
+            bio_object.taxon = self.make_NamedObject(
+                **graph.get_node(tax_edge.obj).as_dict()
+            )
 
-        return obj
+        # Type specific
+        if node_type == 'disease':
+            bio_object.inheritance = []
+            bio_object.clinical_modifiers = []
+            disposition_edges = [edge for edge in graph.edges
+                                 if edge.pred == HAS_DISPOSITION]
+            for disposition_edge in disposition_edges:
+                disposition = graph.get_node(disposition_edge.obj)
+                if 'inheritance' in disposition.meta.category_list:
+                    bio_object.inheritance.append(
+                        self.make_NamedObject(**disposition.as_dict())
+                    )
+                else:
+                    bio_object.clinical_modifiers.append(
+                        self.make_NamedObject(**disposition.as_dict())
+                    )
+
+        return bio_object
 
     def graph(self, id=None, depth=0):
         """

--- a/tests/bioentity-disease.feature
+++ b/tests/bioentity-disease.feature
@@ -23,6 +23,14 @@ TODO - consider swapping subject/object
       and the content should contain "Canis lupus"
       and the content should contain "Gangliosidosis"
 
+ Scenario: User queries for Parkinson disease, late-onset and can see onset and inheritance
+    Given a path "/bioentity/disease/MONDO:0008199"
+     when the content is converted to JSON
+      then the JSON should have some JSONPath "clinical_modifiers[*].id" with "string" "HP:0003676"
+      then the JSON should have some JSONPath "clinical_modifiers[*].label" with "string" "Progressive"
+      then the JSON should have some JSONPath "inheritance[*].id" with "string" "HP:0003745"
+      then the JSON should have some JSONPath "inheritance[*].label" with "string" "Sporadic"
+
 ### Genes
 
  Scenario: User queries for genes associated with lipid storage diseases (e.g. gangliosidosis)


### PR DESCRIPTION
Adds inheritance and onset to bioentity/{type}/{id}.  Note that I'm switching our default scigraph instance to our data graph and pulling all outgoing edges (this may scale poorly).  An alternative would be to allow scigraph neighbors to accept multiple relationship types.  I'm also overloading BioObject with these new fields - alternatively, we could create a disease object and dynamically pass api.models into marshal_with based on the type param.