### PR TITLE
Add a POST method for /ontol/subgraph/ route

### DIFF
--- a/biolink/api/ontol/endpoints/subgraph.py
+++ b/biolink/api/ontol/endpoints/subgraph.py
@@ -35,7 +35,7 @@ class ExtractOntologySubgraphResource(Resource):
 
         ont = get_ontology(ontology)
         relations = args.relation
-        print("Traversing: {} using {}".format(qnodes,relations))
+        log.info("Traversing: {} using {}".format(qnodes,relations))
         nodes = ont.traverse_nodes(qnodes,
                                    up=args.include_ancestors,
                                    down=args.include_descendants,
@@ -59,7 +59,7 @@ class ExtractOntologySubgraphResource(Resource):
 
         ont = get_ontology(ontology)
         relations = args.relation
-        print("Traversing: {} using {}".format(qnodes,relations))
+        log.info("Traversing: {} using {}".format(qnodes,relations))
         nodes = ont.traverse_nodes(qnodes,
                                    up=args.include_ancestors,
                                    down=args.include_descendants,
@@ -70,27 +70,3 @@ class ExtractOntologySubgraphResource(Resource):
         json_obj = ojr.to_json(subont, include_meta=args.include_meta)
 
         return json_obj
-
-# @ns.route('/testme/<ontology>')
-# class TestMe(Resource):
-
-#     @api.expect(parser)
-#     def get(self, ontology):
-#         """
-#         TEST
-#         """
-
-#         ont = get_ontology(ontology)
-#         return {'z': 'foo',
-#                 'nodes': len(ont.nodes())}
-
-
-    
-    
-from flask import g
-def get_db():
-    db = getattr(g, '_database', None)
-    if db is None:
-        logging.info("INITIAL SETUP")
-        db = g._database = 10
-    return db

--- a/biolink/api/ontol/endpoints/subgraph.py
+++ b/biolink/api/ontol/endpoints/subgraph.py
@@ -47,6 +47,29 @@ class ExtractOntologySubgraphResource(Resource):
 
         return json_obj
 
+    @api.expect(parser)
+    def post(self, ontology, node):
+        """
+        Extract a subgraph from an ontology
+        """
+        args = parser.parse_args()
+        qnodes = [node]
+        if args.cnode is not None:
+            qnodes += args.cnode
+
+        ont = get_ontology(ontology)
+        relations = args.relation
+        print("Traversing: {} using {}".format(qnodes,relations))
+        nodes = ont.traverse_nodes(qnodes,
+                                   up=args.include_ancestors,
+                                   down=args.include_descendants,
+                                   relations=relations)
+
+        subont = ont.subontology(nodes, relations=relations)
+        ojr = OboJsonGraphRenderer()
+        json_obj = ojr.to_json(subont, include_meta=args.include_meta)
+
+        return json_obj
 
 # @ns.route('/testme/<ontology>')
 # class TestMe(Resource):
@@ -60,7 +83,7 @@ class ExtractOntologySubgraphResource(Resource):
 #         ont = get_ontology(ontology)
 #         return {'z': 'foo',
 #                 'nodes': len(ont.nodes())}
-    
+
 
     
     


### PR DESCRIPTION
Add a POST method for /ontol/subgraph/ route to support a long list of ontology terms,

Fixes #179 