### PR TITLE
Add missing routes for pathway, genotype, variant and literature types

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -1505,3 +1505,111 @@ class ModelVariantAssociations(Resource):
             user_agent=USER_AGENT,
             **core_parser.parse_args()
         )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteratureVariantAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns variants associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='variant',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteraturePhenotypeAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns phenotypes associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='phenotype',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteratureModelAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns models associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='model',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteratureGenotypeAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns genotypes associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='genotype',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteratureGeneAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns genes associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='gene',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
+class LiteratureDiseaseAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns diseases associated with a literature
+        """
+
+        return search_associations(
+            subject_category='publication',
+            object_category='disease',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -1125,6 +1125,25 @@ class GenotypeGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
+@api.doc(params={'id': 'CURIE identifier of genotype, e.g. MONARCH:FBgeno422705'})
+class GenotypeVariantAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns genotypes-variant associations.
+        """
+
+        return search_associations(
+            subject_category='genotype',
+            object_category='variant',
+            invert_subject_object=True,
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-4286'})
 class GenotypePhenotypeAssociations(Resource):
 
@@ -1206,6 +1225,24 @@ class VariantGenotypeAssociations(Resource):
         return search_associations(
             subject_category='variant',
             object_category='genotype',
+            subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier of variant, e.g. ClinVarVariant:14925'})
+class VariantDiseaseAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns diseases associated with a variant
+        """
+
+        return search_associations(
+            subject_category='variant',
+            object_category='disease',
             subject=id,
             user_agent=USER_AGENT,
             **core_parser.parse_args()

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -1155,7 +1155,6 @@ class GenotypeGenotypeAssociations(Resource):
         Genotypes may be related to one another according to the GENO model
         """
 
-        # TODO: invert
         return search_associations(
             subject_category='genotype',
             object_category='genotype',
@@ -1220,7 +1219,6 @@ class GenotypeDiseaseAssociations(Resource):
         Returns diseases associated with a genotype
         """
 
-        # TODO: invert
         return search_associations(
             subject_category='genotype',
             object_category='disease',
@@ -1239,7 +1237,6 @@ class GenotypeGeneAssociations(Resource):
         Returns genes associated with a genotype
         """
 
-        # TODO: invert
         return search_associations(
             subject_category='genotype',
             object_category='gene',
@@ -1297,7 +1294,6 @@ class VariantGenotypeAssociations(Resource):
         Returns genotypes associated with a variant
         """
 
-        # TODO: invert
         return search_associations(
             subject_category='variant',
             object_category='genotype',
@@ -1361,7 +1357,6 @@ class VariantGeneAssociations(Resource):
         Returns genes associated with a variant
         """
 
-        # TODO: invert
         return search_associations(
             subject_category='variant',
             object_category='gene',

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -49,6 +49,7 @@ TYPE_PATHWAY = 'pathway'
 TYPE_ANATOMY = 'anatomy'
 TYPE_SUBSTANCE = 'substance'
 TYPE_INDIVIDUAL = 'individual'
+TYPE_LITERATURE = 'publication'
 
 core_parser_with_rel = core_parser.copy()
 core_parser_with_rel.add_argument('relationship_type', choices=[INVOLVED_IN, INVOLVED_IN_REGULATION_OF, ACTS_UPSTREAM_OF_OR_WITHIN], default=INVOLVED_IN, help="relationship type ('{}', '{}' or '{}')".format(INVOLVED_IN, INVOLVED_IN_REGULATION_OF, ACTS_UPSTREAM_OF_OR_WITHIN))
@@ -94,7 +95,7 @@ class GenericObject(Resource):
 @api.param('id', 'id, e.g. NCBIGene:84570')
 @api.param('type', 'bioentity type', enum=[TYPE_GENE, TYPE_VARIANT, TYPE_GENOTYPE, TYPE_PHENOTYPE,
                                            TYPE_DISEASE, TYPE_GOTERM, TYPE_PATHWAY, TYPE_ANATOMY,
-                                           TYPE_SUBSTANCE, TYPE_INDIVIDUAL])
+                                           TYPE_SUBSTANCE, TYPE_INDIVIDUAL, TYPE_LITERATURE])
 class GenericObjectByType(Resource):
 
     parser = core_parser.copy()

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -49,7 +49,7 @@ TYPE_PATHWAY = 'pathway'
 TYPE_ANATOMY = 'anatomy'
 TYPE_SUBSTANCE = 'substance'
 TYPE_INDIVIDUAL = 'individual'
-TYPE_LITERATURE = 'publication'
+TYPE_PUBLICATION = 'publication'
 
 core_parser_with_rel = core_parser.copy()
 core_parser_with_rel.add_argument('relationship_type', choices=[INVOLVED_IN, INVOLVED_IN_REGULATION_OF, ACTS_UPSTREAM_OF_OR_WITHIN], default=INVOLVED_IN, help="relationship type ('{}', '{}' or '{}')".format(INVOLVED_IN, INVOLVED_IN_REGULATION_OF, ACTS_UPSTREAM_OF_OR_WITHIN))
@@ -95,7 +95,7 @@ class GenericObject(Resource):
 @api.param('id', 'id, e.g. NCBIGene:84570')
 @api.param('type', 'bioentity type', enum=[TYPE_GENE, TYPE_VARIANT, TYPE_GENOTYPE, TYPE_PHENOTYPE,
                                            TYPE_DISEASE, TYPE_GOTERM, TYPE_PATHWAY, TYPE_ANATOMY,
-                                           TYPE_SUBSTANCE, TYPE_INDIVIDUAL, TYPE_LITERATURE])
+                                           TYPE_SUBSTANCE, TYPE_INDIVIDUAL, TYPE_PUBLICATION])
 class GenericObjectByType(Resource):
 
     parser = core_parser.copy()
@@ -345,7 +345,7 @@ class GeneFunctionAssociations(Resource):
         return assocs
 
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750'})
-class GeneLiteratureAssociations(Resource):
+class GenePublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -568,7 +568,7 @@ class DiseaseGenotypeAssociations(Resource):
         )
 
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
-class DiseaseLiteratureAssociations(Resource):
+class DiseasePublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -744,7 +744,7 @@ class PhenotypeGenotypeAssociations(Resource):
         )
 
 @api.doc(params={'id': 'Pheno class CURIE identifier, e.g  WBPhenotype:0000180 (axon morphology variant), MP:0001569 (abnormal circulating bilirubin level)'})
-class PhenotypeLieratureAssociations(Resource):
+class PhenotypePublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -955,7 +955,7 @@ class FunctionTaxonAssociations(Resource):
 
 
 @api.doc(params={'id': 'CURIE identifier of a GO term, e.g. GO:0044598'})
-class FunctionLiteratureAssociations(Resource):
+class FunctionPublicationAssociations(Resource):
 
     @api.expect(basic_parser)
     def get(self, id):
@@ -1265,7 +1265,7 @@ class GenotypeModelAssociations(Resource):
         )
 
 @api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-6607'})
-class GenotypeLiteratureAssociations(Resource):
+class GenotypePublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -1366,7 +1366,7 @@ class VariantGeneAssociations(Resource):
         )
 
 @api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8, ClinVarVariant:39783'})
-class VariantLiteratureAssociations(Resource):
+class VariantPublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -1439,7 +1439,7 @@ class ModelGenotypeAssociations(Resource):
         )
 
 @api.doc(params={'id': 'CURIE identifier for a model, e.g. MGI:5644542'})
-class ModelLiteratureAssociations(Resource):
+class ModelPublicationAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
@@ -1502,14 +1502,14 @@ class ModelVariantAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteratureVariantAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationVariantAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns variants associated with a literature
+        Returns variants associated with a publication
         """
 
         return search_associations(
@@ -1520,14 +1520,14 @@ class LiteratureVariantAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteraturePhenotypeAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationPhenotypeAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns phenotypes associated with a literature
+        Returns phenotypes associated with a publication
         """
 
         return search_associations(
@@ -1538,14 +1538,14 @@ class LiteraturePhenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteratureModelAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationModelAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns models associated with a literature
+        Returns models associated with a publication
         """
 
         return search_associations(
@@ -1556,14 +1556,14 @@ class LiteratureModelAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteratureGenotypeAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationGenotypeAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns genotypes associated with a literature
+        Returns genotypes associated with a publication
         """
 
         return search_associations(
@@ -1574,14 +1574,14 @@ class LiteratureGenotypeAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteratureGeneAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationGeneAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns genes associated with a literature
+        Returns genes associated with a publication
         """
 
         return search_associations(
@@ -1592,14 +1592,14 @@ class LiteratureGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier for literature/publication, e.g. PMID:11751940'})
-class LiteratureDiseaseAssociations(Resource):
+@api.doc(params={'id': 'CURIE identifier for a publication, e.g. PMID:11751940'})
+class PublicationDiseaseAssociations(Resource):
 
     @api.expect(core_parser)
     @api.marshal_with(association_results)
     def get(self, id):
         """
-        Returns diseases associated with a literature
+        Returns diseases associated with a publication
         """
 
         return search_associations(

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -1008,9 +1008,47 @@ class PathwayGeneAssociations(Resource):
         """
 
         return search_associations(
-            subject_category='gene',
-            object_category='pathway',
-            object=id,
+            subject_category='pathway',
+            object_category='gene',
+            subject=id,
+            invert_subject_object=True,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE any pathway element. E.g. REACT:R-HSA-5387390'})
+class PathwayDiseaseAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns diseases associated with a pathway
+        """
+
+        return search_associations(
+            subject_category='pathway',
+            object_category='disease',
+            subject=id,
+            invert_subject_object=True,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE any pathway element. E.g. REACT:R-HSA-5387390'})
+class PathwayPhenotypeAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns phenotypes associated with a pathway
+        """
+
+        return search_associations(
+            subject_category='pathway',
+            object_category='phenotype',
+            subject=id,
             user_agent=USER_AGENT,
             **core_parser.parse_args()
         )
@@ -1209,6 +1247,43 @@ class GenotypeGeneAssociations(Resource):
             **core_parser.parse_args()
         )
 
+@api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-6607'})
+class GenotypeModelAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns models associated with a genotype
+        """
+
+        return search_associations(
+            subject_category='genotype',
+            object_category='gene',
+            subject=id,
+            invert_subject_object=True,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier of genotype, e.g. ZFIN:ZDB-FISH-150901-6607'})
+class GenotypeLiteratureAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns publications associated with a genotype
+        """
+
+        return search_associations(
+            subject_category='genotype',
+            object_category='publication',
+            subject=id,
+            invert_subject_object=True,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
 ##
 
 @api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8'})
@@ -1290,6 +1365,25 @@ class VariantGeneAssociations(Resource):
             subject_category='variant',
             object_category='gene',
             subject=id,
+            user_agent=USER_AGENT,
+            **core_parser.parse_args()
+        )
+
+@api.doc(params={'id': 'CURIE identifier of variant, e.g. ZFIN:ZDB-ALT-010427-8, ClinVarVariant:39783'})
+class VariantLiteratureAssociations(Resource):
+
+    @api.expect(core_parser)
+    @api.marshal_with(association_results)
+    def get(self, id):
+        """
+        Returns publications associated with a variant
+        """
+
+        return search_associations(
+            subject_category='variant',
+            object_category='publication',
+            subject=id,
+            invert_subject_object=True,
             user_agent=USER_AGENT,
             **core_parser.parse_args()
         )

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -177,6 +177,18 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.ModelPhenotypeAssociations
         - route: /model/<id>/variants
           resource: biolink.api.bio.endpoints.bioentity.ModelVariantAssociations
+        - route: /literature/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.LiteratureVariantAssociations
+        - route: /literature/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.LiteraturePhenotypeAssociations
+        - route: /literature/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.LiteratureModelAssociations
+        - route: /literature/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.LiteratureGenotypeAssociations
+        - route: /literature/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.LiteratureGeneAssociations
+        - route: /literature/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.LiteratureDiseaseAssociations
     - name: association
       description: Retrieve associations between entities or entity and descriptors
       routes:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -139,6 +139,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.SubstanceTreatsAssociations
         - route: /genotype/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.GenotypeGenotypeAssociations
+        - route: /genotype/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeVariantAssociations
         - route: /genotype/<id>/phenotypes
           resource: biolink.api.bio.endpoints.bioentity.GenotypePhenotypeAssociations
         - route: /genotype/<id>/diseases
@@ -147,6 +149,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
         - route: /variant/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
+        - route: /variant/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.VariantDiseaseAssociations
         - route: /variant/<id>/phenotypes
           resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
         - route: /variant/<id>/genes

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -69,8 +69,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.GeneGenotypeAssociations
         - route: /gene/<id>/function
           resource: biolink.api.bio.endpoints.bioentity.GeneFunctionAssociations
-        - route: /gene/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.GeneLiteratureAssociations
+        - route: /gene/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.GenePublicationAssociations
         - route: /gene/<id>/models
           resource: biolink.api.bio.endpoints.bioentity.GeneModelAssociations
         - route: /gene/<id>/ortholog/phenotypes
@@ -91,8 +91,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.DiseaseModelTaxonAssociations
         - route: /disease/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.DiseaseGenotypeAssociations
-        - route: /disease/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.DiseaseLiteratureAssociations
+        - route: /disease/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.DiseasePublicationAssociations
         - route: /disease/<id>/models
           resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
         - route: /disease/<id>/pathways
@@ -109,8 +109,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeGeneByTaxonAssociations
         - route: /phenotype/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeGenotypeAssociations
-        - route: /phenotype/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.PhenotypeLieratureAssociations
+        - route: /phenotype/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.PhenotypePublicationAssociations
         - route: /phenotype/<id>/pathways
           resource: biolink.api.bio.endpoints.bioentity.PhenotypePathwayAssociations
         - route: /phenotype/<id>/variants
@@ -123,8 +123,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.FunctionAssociations
         - route: /function/<id>/taxons
           resource: biolink.api.bio.endpoints.bioentity.FunctionTaxonAssociations
-        - route: /function/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.FunctionLiteratureAssociations
+        - route: /function/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.FunctionPublicationAssociations
         - route: /pathway/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.PathwayGeneAssociations
         - route: /pathway/<id>/diseases
@@ -153,8 +153,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
         - route: /genotype/<id>/models
           resource: biolink.api.bio.endpoints.bioentity.GenotypeModelAssociations
-        - route: /genotype/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.GenotypeLiteratureAssociations
+        - route: /genotype/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.GenotypePublicationAssociations
         - route: /variant/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
         - route: /variant/<id>/diseases
@@ -163,32 +163,32 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
         - route: /variant/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.VariantGeneAssociations
-        - route: /variant/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.VariantLiteratureAssociations
+        - route: /variant/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.VariantPublicationAssociations
         - route: /model/<id>/diseases
           resource: biolink.api.bio.endpoints.bioentity.ModelDiseaseAssociations
         - route: /model/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.ModelGeneAssociations
         - route: /model/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.ModelGenotypeAssociations
-        - route: /model/<id>/literature
-          resource: biolink.api.bio.endpoints.bioentity.ModelLiteratureAssociations
+        - route: /model/<id>/publications
+          resource: biolink.api.bio.endpoints.bioentity.ModelPublicationAssociations
         - route: /model/<id>/phenotypes
           resource: biolink.api.bio.endpoints.bioentity.ModelPhenotypeAssociations
         - route: /model/<id>/variants
           resource: biolink.api.bio.endpoints.bioentity.ModelVariantAssociations
-        - route: /literature/<id>/variants
-          resource: biolink.api.bio.endpoints.bioentity.LiteratureVariantAssociations
-        - route: /literature/<id>/phenotypes
-          resource: biolink.api.bio.endpoints.bioentity.LiteraturePhenotypeAssociations
-        - route: /literature/<id>/models
-          resource: biolink.api.bio.endpoints.bioentity.LiteratureModelAssociations
-        - route: /literature/<id>/genotypes
-          resource: biolink.api.bio.endpoints.bioentity.LiteratureGenotypeAssociations
-        - route: /literature/<id>/genes
-          resource: biolink.api.bio.endpoints.bioentity.LiteratureGeneAssociations
-        - route: /literature/<id>/diseases
-          resource: biolink.api.bio.endpoints.bioentity.LiteratureDiseaseAssociations
+        - route: /publication/<id>/variants
+          resource: biolink.api.bio.endpoints.bioentity.PublicationVariantAssociations
+        - route: /publication/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.PublicationPhenotypeAssociations
+        - route: /publication/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.PublicationModelAssociations
+        - route: /publication/<id>/genotypes
+          resource: biolink.api.bio.endpoints.bioentity.PublicationGenotypeAssociations
+        - route: /publication/<id>/genes
+          resource: biolink.api.bio.endpoints.bioentity.PublicationGeneAssociations
+        - route: /publication/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.PublicationDiseaseAssociations
     - name: association
       description: Retrieve associations between entities or entity and descriptors
       routes:

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -127,6 +127,10 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.FunctionLiteratureAssociations
         - route: /pathway/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.PathwayGeneAssociations
+        - route: /pathway/<id>/diseases
+          resource: biolink.api.bio.endpoints.bioentity.PathwayDiseaseAssociations
+        - route: /pathway/<id>/phenotypes
+          resource: biolink.api.bio.endpoints.bioentity.PathwayPhenotypeAssociations
         - route: /anatomy/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.AnatomyGeneAssociations
         - route: /anatomy/<id>/genes/<taxid>
@@ -147,6 +151,10 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.GenotypeDiseaseAssociations
         - route: /genotype/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.GenotypeGeneAssociations
+        - route: /genotype/<id>/models
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeModelAssociations
+        - route: /genotype/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.GenotypeLiteratureAssociations
         - route: /variant/<id>/genotypes
           resource: biolink.api.bio.endpoints.bioentity.VariantGenotypeAssociations
         - route: /variant/<id>/diseases
@@ -155,6 +163,8 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.VariantPhenotypeAssociations
         - route: /variant/<id>/genes
           resource: biolink.api.bio.endpoints.bioentity.VariantGeneAssociations
+        - route: /variant/<id>/literature
+          resource: biolink.api.bio.endpoints.bioentity.VariantLiteratureAssociations
         - route: /model/<id>/diseases
           resource: biolink.api.bio.endpoints.bioentity.ModelDiseaseAssociations
         - route: /model/<id>/genes

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -99,7 +99,7 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
         - route: /disease/<id>/variants
           resource: biolink.api.bio.endpoints.bioentity.DiseaseVariantAssociations
-        - route: phenotype/<id>/anatomy
+        - route: /phenotype/<id>/anatomy
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeAnatomyAssociations
         - route: /phenotype/<id>/diseases
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeDiseaseAssociations


### PR DESCRIPTION
Added following routes to bioentity namespace:

- `/pathway/<id>/phenotypes`
- `/pathway/<id>/diseases`
- `/genotype/<id>/models`
- `/genotype/<id>/literature`
- `/variant/<id>/literature`
- `/literature/<id>/variants`
- `/literature/<id>/phenotypes`
- `/literature/<id>/models`
- `/literature/<id>/genotypes`
- `/literature/<id>/genes`
- `/literature/<id>/diseases`