### PR TITLE
fix association counts, clinical modifiers, and inheritance

### DIFF
--- a/biolink/api/bio/association_counts.py
+++ b/biolink/api/bio/association_counts.py
@@ -51,13 +51,13 @@ def get_association_counts(bioentity_id, bioentity_type=None):
         fq={'subject_closure': bioentity_id},
         facet_pivot_fields=['{!stats=piv1}object_category', 'relation'],
         stats=True,
-        stats_fields=['{!tag=piv1 calcdistinct=true distinctValues=false}object']
+        stats_field=['{!tag=piv1 calcdistinct=true distinctValues=false}object']
     )
     object_associations = search_associations(
         fq={'object_closure': bioentity_id},
         facet_pivot_fields=['{!stats=piv1}subject_category', 'relation'],
         stats=True,
-        stats_fields=['{!tag=piv1 calcdistinct=true distinctValues=false}subject']
+        stats_field=['{!tag=piv1 calcdistinct=true distinctValues=false}subject']
     )
     subject_facet_pivot = subject_associations['facet_pivot']['object_category,relation']
     object_facet_pivot = object_associations['facet_pivot']['subject_category,relation']
@@ -71,7 +71,7 @@ def get_association_counts(bioentity_id, bioentity_type=None):
             fq={'subject_ortholog_closure': bioentity_id},
             facet_pivot_fields=['{!stats=piv1}object_category', 'relation'],
             stats=True,
-            stats_fields=['{!tag=piv1 calcdistinct=true distinctValues=false}object']
+            stats_field=['{!tag=piv1 calcdistinct=true distinctValues=false}object']
         )
 
         ortholog_pivot_counts = ortholog_associations['facet_pivot']['object_category,relation']

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -101,19 +101,23 @@ class GenericObjectByType(Resource):
     parser.add_argument('get_association_counts', help='Get association counts', type=inputs.boolean, default=False)
 
     @api.expect(parser)
-    @api.marshal_with(bio_object)
     def get(self, id, type):
         """
         Return basic info on an object for a given type
         """
         args = self.parser.parse_args()
         if type == TYPE_DISEASE:
-            ret_val = marshal(scigraph.bioobject(id, type), disease_object), 200
+            bio_entity = scigraph.bioobject(id, type)
+            ret_val = marshal(bio_entity, disease_object), 200
         else:
+            bio_entity = scigraph.bioobject(id, type)
             ret_val = marshal(scigraph.bioobject(id, type), bio_object), 200
         if args['get_association_counts']:
-            ret_val[0]['association_counts'] = get_association_counts(id, type)
+            # *_ortholog_closure requires clique leader, so use
+            # bio_entity.id instead of incoming id
+            ret_val[0]['association_counts'] = get_association_counts(bio_entity.id, type)
         return ret_val
+
 
 class GenericAssociations(Resource):
 

--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -111,7 +111,7 @@ class GenericObjectByType(Resource):
             ret_val = marshal(bio_entity, disease_object), 200
         else:
             bio_entity = scigraph.bioobject(id, type)
-            ret_val = marshal(scigraph.bioobject(id, type), bio_object), 200
+            ret_val = marshal(bio_entity, bio_object), 200
         if args['get_association_counts']:
             # *_ortholog_closure requires clique leader, so use
             # bio_entity.id instead of incoming id

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -99,7 +99,7 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
         - route: /disease/<id>/variants
           resource: biolink.api.bio.endpoints.bioentity.DiseaseVariantAssociations
-        - route: phenotype/<id>/anatomy
+        - route: /phenotype/<id>/anatomy
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeAnatomyAssociations
         - route: /phenotype/<id>/diseases
           resource: biolink.api.bio.endpoints.bioentity.PhenotypeDiseaseAssociations


### PR DESCRIPTION
- Fixes bug in stats_field
-  @api.marshal_with(bio_object) decorator broke dynamic marshalling (for inheritance, clin mod)
- Use clique leader for collecting stats (for gene ortholog stats)
 
When pushed to production the following should work:
http://api.monarchinitiative.org/api/bioentity/disease/OMIM%3A168600?rows=100&unselect_evidence=false&exclude_automatic_assertions=false&fetch_objects=true&use_compact_associations=false&get_association_counts=true

http://api.monarchinitiative.org/api/bioentity/gene/NCBIGene%3A84570?rows=100&unselect_evidence=false&exclude_automatic_assertions=false&fetch_objects=true&use_compact_associations=false&get_association_counts=true