### PR TITLE
Improve error handling

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -17,6 +17,8 @@ from ontobio.golr.golr_query import run_solr_text_on, ESOLR, ESOLRDoc, replace
 from ontobio.config import get_config
 import json
 
+from biolink.error_handlers import default_error_handler, no_result_found_exception_handler, unhandled_exception_handler
+from biolink.error_handlers import NoResultFoundException, UnhandledException, UnrecognizedBioentityTypeException
 
 log = logging.getLogger(__name__)
 
@@ -112,20 +114,22 @@ class GenericObjectByType(Resource):
         """
         ret_val = None
         args = self.parser.parse_args()
-        if type in categories:
-            if type == TYPE_DISEASE:
-                bio_entity = scigraph.bioobject(id, type)
-                ret_val = marshal(bio_entity, disease_object), 200
-            else:
-                bio_entity = scigraph.bioobject(id, type)
-                ret_val = marshal(bio_entity, bio_object), 200
 
-            if args['get_association_counts']:
-                # *_ortholog_closure requires clique leader, so use
-                # bio_entity.id instead of incoming id
-                ret_val[0]['association_counts'] = get_association_counts(bio_entity.id, type)
+        if type not in categories:
+            raise UnrecognizedBioentityTypeException("{} is not a valid Bioentity type".format(type))
+
+        if type == TYPE_DISEASE:
+            bio_entity = scigraph.bioobject(id, type)
+            ret_val = marshal(bio_entity, disease_object), 200
         else:
-            ret_val = {}
+            bio_entity = scigraph.bioobject(id, type)
+            ret_val = marshal(bio_entity, bio_object), 200
+
+        if args['get_association_counts']:
+            # *_ortholog_closure requires clique leader, so use
+            # bio_entity.id instead of incoming id
+            ret_val[0]['association_counts'] = get_association_counts(bio_entity.id, type)
+
         return ret_val
 
 

--- a/biolink/api/entityset/endpoints/summary.py
+++ b/biolink/api/entityset/endpoints/summary.py
@@ -1,12 +1,12 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import compact_association_set, association_results
 from ontobio.golr.golr_associations import search_associations, GolrFields
 
 from biolink.api.restplus import api
 from biolink import USER_AGENT
+from biolink.error_handlers import RouteNotImplementedException
 
 MAX_ROWS=10000
 
@@ -101,6 +101,4 @@ class EntitySetGraphResource(Resource):
         """
         args = parser.parse_args()
 
-        return "TODO"    
-    
-
+        raise RouteNotImplementedException()

--- a/biolink/api/genome/endpoints/region.py
+++ b/biolink/api/genome/endpoints/region.py
@@ -1,10 +1,10 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import sequence_feature
 from biolink.api.restplus import api
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -20,10 +20,4 @@ class FeaturesWithinResource(Resource):
         Returns list of matches
         """
         args = parser.parse_args()
-
-        return []
-
-
-    
-    
-
+        raise RouteNotImplementedException()

--- a/biolink/api/identifier/endpoints/mapper.py
+++ b/biolink/api/identifier/endpoints/mapper.py
@@ -1,10 +1,10 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -23,10 +23,4 @@ class IdentifierMapper(Resource):
         TODO maps a list of identifiers from a source to a target
         """
         args = parser.parse_args()
-
-        return []
-
-
-    
-    
-
+        raise RouteNotImplementedException()

--- a/biolink/api/nlp/endpoints/annotate.py
+++ b/biolink/api/nlp/endpoints/annotate.py
@@ -4,6 +4,7 @@ from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
+from biolink.error_handlers import RouteNotImplementedException
 import pysolr
 
 log = logging.getLogger(__name__)
@@ -24,9 +25,4 @@ class Annotate(Resource):
         """
         args = parser.parse_args()
 
-        return []
-
-
-    
-    
-
+        raise RouteNotImplementedException('Use SciGraph annotator instead')

--- a/biolink/api/owl/endpoints/ontology.py
+++ b/biolink/api/owl/endpoints/ontology.py
@@ -1,10 +1,10 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -15,21 +15,14 @@ class DLQuery(Resource):
 
     @api.expect(parser)
     @api.marshal_list_with(association)
-
-    @api.expect(parser)
-    @api.marshal_list_with(association)
     def get(self, query):
         """
         Placeholder - use OWLery for now
         """
         args = parser.parse_args()
-
-        return []
+        raise RouteNotImplementedException('Use Owlery API instead')
 
 class SparqlQuery(Resource):
-
-    @api.expect(parser)
-    @api.marshal_list_with(association)
 
     @api.expect(parser)
     @api.marshal_list_with(association)
@@ -38,10 +31,5 @@ class SparqlQuery(Resource):
         Placeholder - use direct SPARQL endpoint for now
         """
         args = parser.parse_args()
-
-        return []
-    
-
-    
-    
+        raise RouteNotImplementedException('Use SPARQL endpoint directly')
 

--- a/biolink/api/patient/endpoints/individual.py
+++ b/biolink/api/patient/endpoints/individual.py
@@ -1,10 +1,10 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -15,33 +15,20 @@ class Individual(Resource):
 
     @api.expect(parser)
     @api.marshal_list_with(association)
-
-    @api.expect(parser)
-    @api.marshal_list_with(association)
     def get(self, id):
         """
         Returns list of matches
         """
         args = parser.parse_args()
-
-        return []
+        raise RouteNotImplementedException()
 
 class Pedigree(Resource):
 
     @api.expect(parser)
     @api.marshal_list_with(association)
-
-    @api.expect(parser)
-    @api.marshal_list_with(association)
     def get(self, id):
         """
         Returns list of matches
         """
         args = parser.parse_args()
-
-        return []
-    
-
-    
-    
-
+        raise RouteNotImplementedException()

--- a/biolink/api/variation/endpoints/analyze.py
+++ b/biolink/api/variation/endpoints/analyze.py
@@ -1,10 +1,10 @@
 import logging
 
-from flask import request
 from flask_restplus import Resource
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -15,16 +15,12 @@ class Analyze(Resource):
 
     @api.expect(parser)
     @api.marshal_list_with(association)
-
-    @api.expect(parser)
-    @api.marshal_list_with(association)
     def get(self, term):
         """
         Returns list of matches
         """
         args = parser.parse_args()
-
-        return []
+        raise RouteNotImplementedException()
 
     
 

--- a/biolink/api/variation/endpoints/variantset.py
+++ b/biolink/api/variation/endpoints/variantset.py
@@ -7,7 +7,8 @@ from biolink.api.variation.business import create_variantset, update_variantset,
 from biolink.datamodel.serializers import association
 from biolink.api.restplus import api
 from biolink.database.models import VariantSet
-import pysolr
+
+from biolink.error_handlers import RouteNotImplementedException
 
 log = logging.getLogger(__name__)
 
@@ -125,6 +126,5 @@ class VariantAnalyze(Resource):
         Returns list of matches
         """
         args = parser.parse_args()
-
-        return []
+        raise RouteNotImplementedException()
     

--- a/biolink/app.py
+++ b/biolink/app.py
@@ -28,7 +28,7 @@ app.config['SWAGGER_UI_DOC_EXPANSION'] = settings.RESTPLUS_SWAGGER_UI_DOC_EXPANS
 app.config['RESTPLUS_VALIDATE'] = settings.RESTPLUS_VALIDATE
 app.config['RESTPLUS_MASK_SWAGGER'] = settings.RESTPLUS_MASK_SWAGGER
 app.config['ERROR_404_HELP'] = settings.RESTPLUS_ERROR_404_HELP
-
+app.config['ERROR_INCLUDE_MESSAGE'] = settings.ERROR_INCLUDE_MESSAGE
 
 #def initialize_app(flask_app):
 #    configure_app(flask_app)

--- a/biolink/error_handlers.py
+++ b/biolink/error_handlers.py
@@ -1,0 +1,175 @@
+from prefixcommons.curie_util import InvalidSyntax, NoExpansion, NoContraction, NoPrefix, AmbiguousPrefix
+
+from biolink.api.restplus import api
+from biolink import settings
+import logging
+
+class CustomException(Exception):
+    def __init__(self, message, status_code=400, debug=None):
+        Exception.__init__(self)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        if settings.FLASK_DEBUG:
+            self.debug = debug
+
+    def to_dict(self):
+        return {
+            'error': {
+                'message': self.message,
+                'code': self.status_code,
+                'debug': dict(self.debug or ())
+            }
+        }
+
+class NoResultFoundException(CustomException):
+    """
+    Use this exception when results are expected but no result found
+    """
+    def __init__(self, message, status_code=400, debug=None):
+        CustomException.__init__(self, message, status_code, debug)
+
+class UnrecognizedBioentityTypeException(CustomException):
+    """
+    Use this exception when encountering an unrecognized Bioentity type
+    """
+    def __init__(self, message, status_code=400, debug=None):
+        CustomException.__init__(self, message, status_code, debug)
+
+class RouteNotImplementedException(CustomException):
+    """
+    Use this exception for routes that have yet to be implemented
+    """
+    def __init__(self, message=None, status_code=500, debug=None):
+        if not message:
+            message = 'Route not yet implemented'
+        CustomException.__init__(self, message, status_code, debug)
+
+class UnhandledException(CustomException):
+    """
+    Use this exception if its unclear which exception to raise
+    """
+    def __init__(self, message, status_code=500, debug=None):
+        CustomException.__init__(self, message, status_code, debug)
+
+@api.errorhandler
+def default_error_handler(e):
+    """
+    Default error handler
+    """
+    status_code = 500
+    message = 'An exception occurred: {}'.format(e)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': status_code
+        }
+    }, status_code
+
+@api.errorhandler(NoResultFoundException)
+def no_result_found_exception_handler(e):
+    """
+    Error handler to handle NoResultFoundException
+    """
+    message = e.message
+    logging.error(message)
+    return e.to_dict(), e.status_code
+
+@api.errorhandler(UnrecognizedBioentityTypeException)
+def unrecognized_bioentity_type_exception(e):
+    """
+    Error handler to handle UnrecognizedBioentityTypeException
+    """
+
+    message = e.message
+    logging.error(message)
+    return e.to_dict(), e.status_code
+
+@api.errorhandler(RouteNotImplementedException)
+def route_not_implemented_exception(e):
+    """
+    Error handler to handle RouteNotImplementedException
+    """
+    message = e.message
+    logging.error(message)
+    return e.to_dict(), e.status_code
+
+@api.errorhandler(UnhandledException)
+def unhandled_exception_handler(e):
+    """
+    Error handler to handle UnhandledException
+    """
+    message = e.message
+    logging.error(message)
+    return e.to_dict(), e.status_code
+
+@api.errorhandler(InvalidSyntax)
+def invalid_syntax_exception_handler(e):
+    """
+    Error handler to handle InvalidSyntax
+    """
+    message = 'Invalid syntax for CURIE {}'.format(e.id)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': 400
+        }
+    }, 400
+
+@api.errorhandler(NoExpansion)
+def no_expansion_exception_handler(e):
+    """
+    Error handler to handle NoExpansion
+    """
+    message = 'No expansion for {}'.format(e.id)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': 400
+        }
+    }, 400
+
+@api.errorhandler(NoContraction)
+def no_contraction_exception_handler(e):
+    """
+    Error handler to handle NoContraction
+    """
+    message = 'No contraction for URI {}'.format(e.uri)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': 400
+        }
+    }, 400
+
+@api.errorhandler(NoPrefix)
+def no_prefix_exception_handler(e):
+    """
+    Error handler to handle NoPrefix
+    """
+    message = 'No prefix for URI {}'.format(e.uri)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': 400
+        }
+    }, 400
+
+@api.errorhandler(AmbiguousPrefix)
+def ambiguous_prefix_exception_handler(e):
+    """
+    Error handler to handle AmbiguousPrefix
+    """
+    message = 'Ambiguous prefix for URI {}'.format(e.uri)
+    logging.error(message)
+    return {
+        'error': {
+            'message': message,
+            'code': 400
+        }
+    }, 400

--- a/biolink/error_handlers.py
+++ b/biolink/error_handlers.py
@@ -5,7 +5,7 @@ from biolink import settings
 import logging
 
 class CustomException(Exception):
-    def __init__(self, message, status_code=400, debug=None):
+    def __init__(self, message, status_code=500, debug=None):
         Exception.__init__(self)
         self.message = message
         if status_code is not None:
@@ -26,7 +26,7 @@ class NoResultFoundException(CustomException):
     """
     Use this exception when results are expected but no result found
     """
-    def __init__(self, message, status_code=400, debug=None):
+    def __init__(self, message, status_code=404, debug=None):
         CustomException.__init__(self, message, status_code, debug)
 
 class UnrecognizedBioentityTypeException(CustomException):

--- a/biolink/settings.py
+++ b/biolink/settings.py
@@ -11,6 +11,10 @@ RESTPLUS_VALIDATE = True
 RESTPLUS_MASK_SWAGGER = False
 RESTPLUS_ERROR_404_HELP = False
 
+# This is set to false to prevent Flask-Restplus from
+# changing the error message structure
+ERROR_INCLUDE_MESSAGE = False
+
 # SQLAlchemy settings
 SQLALCHEMY_DATABASE_URI = 'sqlite:///db.sqlite'
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
This PR adds the ability to handle errors and exceptions.

- Added few appropriate Exception classes
- Added related exception handlers
- Raise the proper exceptions

This ensures that a user never has to see an error message like this:
```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>500 Internal Server Error</title>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.</p>
```


Instead, the response will always be a JSON, even in the case of errors on the server:
```json
{
    "error": {
        "message": "SciGraph dynamic/cliqueLeader yields no result for PMID:28847661",
        "code": 400,
        "debug": {}
    }
}
```

This is an initial take at better handling and propagating the underlying problem to the user.

Even if Ontobio encounters an exception, there is now a default exception handler in BioLink API that will handle it.
