### PR TITLE
Add filters to routes

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -608,25 +608,6 @@ class DiseasePublicationAssociations(Resource):
             **core_parser.parse_args()
         )
 
-@api.doc(params={'id': 'CURIE identifier of disease, e.g. OMIM:605543, DOID:678. Equivalent IDs can be used with same results'})
-class DiseaseModelAssociations(Resource):
-
-    @api.expect(core_parser)
-    @api.marshal_with(association_results)
-    def get(self, id):
-        """
-        Returns models associated with a disease
-        """
-
-        # Note: ontobio automagically sets invert_subject_object when (subject,object) is (disease,model)
-        return search_associations(
-            subject_category='disease',
-            object_category='model',
-            subject=id,
-            user_agent=USER_AGENT,
-            **core_parser.parse_args()
-        )
-
 @api.doc(params={'id': 'CURIE identifier of disease, e.g. DOID:4450. Equivalent IDs can be used with same results'})
 class DiseasePathwayAssociations(Resource):
 

--- a/biolink/api/link/endpoints/associations_from.py
+++ b/biolink/api/link/endpoints/associations_from.py
@@ -10,22 +10,20 @@ from biolink import USER_AGENT
 
 log = logging.getLogger(__name__)
 
-parser = api.parser()
-parser.add_argument('subject_category', help='Category of entity at link Subject (source), e.g. gene, disease, phenotype')
-parser.add_argument('object_category', help='Category of entity at link Object (target), e.g. gene, disease, phenotype')
-parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
-parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
-parser.add_argument('evidence', help='Object ID, e.g. ECO:0000501 (for IEA; Includes inferred associations, by default), a specific publication or other supporting object, e.g. ZFIN:ZDB-PUB-060503-2')
-parser.add_argument('graphize', type=inputs.boolean, default=False, help='If true, includes graph object in response')
-parser.add_argument('unselect_evidence', type=inputs.boolean, default=False, help='If true, excludes evidence objects in response')
-parser.add_argument('start', type=int, required=False, default=0, help='beginning row')
-parser.add_argument('rows', type=int, required=False, default=10, help='number of rows')
-parser.add_argument('map_identifiers', help='Prefix to map all IDs to, e.g. NCBIGene')
-parser.add_argument('slim', action='append', help='Map objects up (slim) to a higher level category. Value can be ontology class ID or subset ID')
-parser.add_argument('use_compact_associations', type=inputs.boolean, default=False, help='If true, returns results in compact associations format')
+core_parser = api.parser()
+core_parser.add_argument('rows', type=int, required=False, default=100, help='number of rows')
+core_parser.add_argument('start', type=int, required=False, help='beginning row')
+core_parser.add_argument('evidence', help='Object id, e.g. ECO:0000501 (for IEA; Includes inferred by default) or a specific publication or other supporting object, e.g. ZFIN:ZDB-PUB-060503-2')
+core_parser.add_argument('unselect_evidence', type=inputs.boolean, default=False, help='If true, excludes evidence objects in response')
+core_parser.add_argument('exclude_automatic_assertions', type=inputs.boolean, default=False, help='If true, excludes associations that involve IEAs (ECO:0000501)')
+core_parser.add_argument('use_compact_associations', type=inputs.boolean, default=False, help='If true, returns results in compact associations format')
 
 @api.doc(params={'subject': 'Return associations emanating from this node, e.g. NCBIGene:84570, ZFIN:ZDB-GENE-050417-357 (If ID is from an ontology then results would include inferred associations, by default)'})
 class AssociationsFrom(Resource):
+
+    parser = core_parser.copy()
+    parser.add_argument('object_taxon', help='Object taxon ID, e.g. NCBITaxon:10090 (Includes inferred associations, by default)')
+    parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
 
     @api.expect(parser)
     @api.marshal_list_with(association_results)
@@ -33,28 +31,30 @@ class AssociationsFrom(Resource):
         """
         Returns list of matching associations starting from a given subject (source)
         """
-        args = parser.parse_args()
-
+        args = self.parser.parse_args()
         return search_associations(subject=subject, user_agent=USER_AGENT, **args)
 
 @api.doc(params={'object': 'Return associations pointing to this node, e.g. specifying MP:0013765 will return all genes, variants, strains, etc. annotated with this term. Can also be a biological entity such as a gene'})
 class AssociationsTo(Resource):
 
-    @api.expect(parser)
+    parser = core_parser.copy()
+    parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
+    parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
+
+    @api.expect(core_parser)
     @api.marshal_list_with(association_results)
     def get(self, object):
         """
         Returns list of matching associations pointing to a given object (target)
         """
-        args = parser.parse_args()
-
+        args = self.parser.parse_args()
         return search_associations(object=object, user_agent=USER_AGENT, **args)
 
 @api.doc(params={'subject': 'Return associations emanating from this node, e.g. MGI:1342287 (If ID is from an ontology then results would include inferred associations, by default)'})
 @api.doc(params={'object': 'Return associations pointing to this node, e.g. MP:0013765. Can also be a biological entity such as a gene'})
 class AssociationsBetween(Resource):
 
-    @api.expect(parser)
+    @api.expect(core_parser)
     @api.marshal_list_with(association_results)
     def get(self, subject, object):
         """
@@ -65,8 +65,5 @@ class AssociationsBetween(Resource):
         the connection.
         
         """
-        args = parser.parse_args()
-        return search_associations(object=object, user_agent=USER_AGENT, **args)
-    
-    
-
+        args = core_parser.parse_args()
+        return search_associations(subject=subject, object=object, user_agent=USER_AGENT, **args)

--- a/biolink/api/link/endpoints/find_associations.py
+++ b/biolink/api/link/endpoints/find_associations.py
@@ -12,74 +12,64 @@ log = logging.getLogger(__name__)
 
 M=GolrFields()
 
-parser = api.parser()
-parser.add_argument('subject', help='Return associations emanating from this node, e.g. NCBIGene:84570, ZFIN:ZDB-GENE-050417-357 (If ID is from an ontology then results would include inferred associations, by default)')
-parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
-parser.add_argument('object', help='Return associations pointing to this node, e.g. HP:0011927 (If ID is from an ontology then results would include inferred associations, by default)')
-parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
-parser.add_argument('evidence', help='Object ID, e.g. ECO:0000501 (for IEA; Includes inferred associations, by default), a specific publication or other supporting object, e.g. ZFIN:ZDB-PUB-060503-2')
-parser.add_argument('graphize', type=inputs.boolean, default=False, help='If true, includes graph object in response')
-parser.add_argument('unselect_evidence', type=inputs.boolean, default=False, help='If true, excludes evidence objects in response')
-parser.add_argument('start', type=int, required=False, default=0, help='beginning row')
-parser.add_argument('rows', type=int, required=False, default=10, help='number of rows')
-parser.add_argument('map_identifiers', help='Prefix to map all IDs to, e.g. NCBIGene')
+core_parser = api.parser()
+core_parser.add_argument('rows', type=int, required=False, default=100, help='number of rows')
+core_parser.add_argument('start', type=int, required=False, help='beginning row')
+core_parser.add_argument('evidence', help='Object id, e.g. ECO:0000501 (for IEA; Includes inferred by default) or a specific publication or other supporting object, e.g. ZFIN:ZDB-PUB-060503-2')
+core_parser.add_argument('unselect_evidence', type=inputs.boolean, default=False, help='If true, excludes evidence objects in response')
+core_parser.add_argument('exclude_automatic_assertions', type=inputs.boolean, default=False, help='If true, excludes associations that involve IEAs (ECO:0000501)')
+core_parser.add_argument('use_compact_associations', type=inputs.boolean, default=False, help='If true, returns results in compact associations format')
+
 
 @api.doc(params={'id': 'identifier for an association, e.g. f5ba436c-f851-41b3-9d9d-bb2b5fc879d4'}, required=True)
 class AssociationObject(Resource):
 
-    @api.expect(parser)
-    @api.marshal_list_with(association)
-    def get(self,id):
+    @api.marshal_list_with(association_results)
+    def get(self, id):
         """
         Returns the association with a given identifier.
 
         An association connects, at a minimum, two things, designated subject and object,
         via some relationship. Associations also include evidence, provenance etc.
         """
-        args = parser.parse_args()
-
-        return get_association(id, user_agent=USER_AGENT)
-
-class AssociationSearch(Resource):
-
-    @api.expect(parser)
-    @api.marshal_list_with(association_results)
-    def get(self):
-        """
-        Generalized search over complete corpus of associations
-        """
-        args = parser.parse_args()
-
-        return search_associations(user_agent=USER_AGENT, **args)
+        return search_associations(id=id, user_agent=USER_AGENT)
 
 @api.doc(params={'subject_category': 'Category of entity at link Subject (source), e.g. gene, disease, phenotype'}, required=True)
 class AssociationBySubjectCategorySearch(Resource):
+
+    parser = core_parser.copy()
+    parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
+    parser.add_argument('object_taxon', help='Object taxon ID, e.g. NCBITaxon:10090 (Includes inferred associations, by default)')
+    parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
 
     @api.expect(parser)
     @api.marshal_list_with(association_results)
     def get(self, subject_category='gene'):
         """
-        Returns list of matching associations for a given Subject category
+        Returns list of matching associations for a given subject category.
         """
-        args = parser.parse_args()
-
+        args = self.parser.parse_args()
         return search_associations(subject_category=subject_category, user_agent=USER_AGENT, **args)
 
 @api.doc(params={'subject_category': 'Category of entity at link Subject (source), e.g. gene, disease, phenotype'})
 @api.doc(params={'object_category': 'Category of entity at link Object (target), e.g. gene, disease, phenotype'})
 class AssociationBySubjectAndObjectCategorySearch(Resource):
 
+    parser = core_parser.copy()
+    parser.add_argument('subject_taxon', help='Subject taxon ID, e.g. NCBITaxon:9606 (Includes inferred associations, by default)')
+    parser.add_argument('object_taxon', help='Object taxon ID, e.g. NCBITaxon:10090 (Includes inferred associations, by default)')
+    parser.add_argument('relation', help='Filter by relation CURIE, e.g. RO:0002200 (has_phenotype), RO:0002607 (is marker for), RO:HOM0000017 (orthologous to), etc.')
+
     @api.expect(parser)
     @api.marshal_list_with(association_results)
-    def get(self, subject_category='gene', object_category='gene'):
+    def get(self, subject_category, object_category):
         """
-        Returns list of matching associations between a given Subject and Object category
+        Returns list of matching associations between a given subject and object category
         """
-        args = parser.parse_args()
+        args = self.parser.parse_args()
         return search_associations(
             subject_category=subject_category,
             object_category=object_category,
             user_agent=USER_AGENT,
             **args
         )
-

--- a/conf/routes.yaml
+++ b/conf/routes.yaml
@@ -150,8 +150,6 @@ route_mapping:
       routes:
         - route: /<id>
           resource: biolink.api.link.endpoints.find_associations.AssociationObject
-        - route: /find
-          resource: biolink.api.link.endpoints.find_associations.AssociationSearch
         - route: /find/<subject_category>
           resource: biolink.api.link.endpoints.find_associations.AssociationBySubjectCategorySearch
         - route: /find/<subject_category>/<object_category>

--- a/conf/routes.yaml
+++ b/conf/routes.yaml
@@ -51,8 +51,6 @@ route_mapping:
           resource: biolink.api.bio.endpoints.bioentity.DiseaseGenotypeAssociations
         - route: /disease/<id>/publications
           resource: biolink.api.bio.endpoints.bioentity.DiseasePublicationAssociations
-        - route: /disease/<id>/models
-          resource: biolink.api.bio.endpoints.bioentity.DiseaseModelAssociations
         - route: /disease/<id>/pathways
           resource: biolink.api.bio.endpoints.bioentity.DiseasePathwayAssociations
         - route: /disease/<id>/variants


### PR DESCRIPTION
This PR adds the following,
- a `taxon` parameter to filter associations based on one or more object taxon
- a `relation` parameter to filter associations based on a given relation CURIE
- remove redundant routes
- deprecate taxon specific routes

Fixes #267