### PR TITLE
Add iri and category for subject and object in association results

### DIFF
--- a/biolink/api/evidence/endpoints/graph.py
+++ b/biolink/api/evidence/endpoints/graph.py
@@ -35,7 +35,7 @@ class EvidenceGraphObject(Resource):
         ## assoc = get_association(id)
         
         results = search_associations(fq={'id':id}, user_agent=USER_AGENT)
-        assoc = results['associations'][0]
+        assoc = results['associations'][0] if len(results['associations']) > 0 else {}
         eg = assoc.get('evidence_graph')
         return [eg]
 

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -79,13 +79,14 @@ bbop_graph = api.model('Graph', {
 
 named_object_core = api.model('NamedObjectCore', {
     'id': fields.String(readOnly=True, description='ID or CURIE e.g. MGI:1201606', required=True),
-    'label': fields.String(readOnly=True, description='RDFS Label')
+    'label': fields.String(readOnly=True, description='RDFS Label'),
+    'iri': fields.String(readOnly=True, description='IRI'),
+    'category': fields.List(fields.String(readOnly=True, description='Type of object'))
 })
 
 
 named_object = api.inherit('NamedObject', named_object_core, {
     'description': fields.String(readOnly=True, description='Descriptive text for the entity. For ontology classes, this will be a definition.'),
-    'categories': fields.List(fields.String(readOnly=True, description='Type of object (inferred)')),
     'types': fields.List(fields.String(readOnly=True, description='Type of object (direct)')),
     'synonyms': fields.List(fields.Nested(synonym_property_value), description='list of synonyms or alternate labels'),
     'deprecated': fields.Boolean(description='True if the node is deprecated/obsoleted.'),
@@ -96,7 +97,6 @@ named_object = api.inherit('NamedObject', named_object_core, {
 entity_reference = api.model('EntityReference', {
     'id': fields.String(readOnly=True, description='ID or CURIE e.g. MGI:1201606'),
     'label': fields.String(readOnly=True, description='RDFS Label'),
-    'categories': fields.List(fields.String(readOnly=True, description='Type of object')),
 })
 
 relation = api.inherit('Relation', named_object, {


### PR DESCRIPTION
This PR adds `iri` and `category` for subject and object when fetching associations.

Fixes #263 and #264 

**Note:** This PR is dependent on https://github.com/biolink/ontobio/pull/316