### PR TITLE
Get metadata for datasets

### DIFF
--- a/biolink/api/metadata/endpoints/datasets.py
+++ b/biolink/api/metadata/endpoints/datasets.py
@@ -1,0 +1,17 @@
+from biolink.api.restplus import api
+from flask_restplus import Resource
+from biolink.settings import get_biolink_config
+from scigraph.scigraph_util import SciGraph
+
+
+scigraph = SciGraph(get_biolink_config()['scigraph_data']['url'])
+
+
+class MetadataForDatasets(Resource):
+
+    def get(self):
+        """
+        Get metadata for all datasets from SciGraph
+        """
+
+        return scigraph.get_datasets()

--- a/conf/routes.yaml
+++ b/conf/routes.yaml
@@ -403,3 +403,8 @@ route_mapping:
             resource: biolink.api.sim.endpoints.semanticsim.SimSearch
           - route: /compare
             resource: biolink.api.sim.endpoints.semanticsim.SimCompare
+    - name: metadata
+      description: Get metadata
+      routes:
+          - route: /datasets
+            resource: biolink.api.metadata.endpoints.datasets.MetadataForDatasets

--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -373,7 +373,17 @@ class SciGraph:
         bbg = self.neighbors(id, direction='INCOMING', depth=1)
         return bbg_to_assocs(bbg)
 
-
+    def get_datasets(self):
+        """
+        Get metadata about all the datasets in SciGraph
+        """
+        response = self.get_response("dynamic/ontologies", None, "json")
+        response_json = response.json()
+        datasets = []
+        for n in response_json['nodes']:
+            if 'MonarchData' in n['id']:
+                datasets.append(n)
+        return datasets
 
 def bbg_to_assocs(g):
     return [bbedge_to_assoc(e,g) for e in g.edges]


### PR DESCRIPTION
Add route to fetch metadata for datasets from SciGraph.

Currently the metadata is minimal. 
Will depend on future ingest for a more detailed metadata.

@kshefchek @cmungall

Related to https://github.com/monarch-initiative/monarch-ui/issues/58