### PR TITLE
Add onset and frequency to disease phenotype associations

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -2,7 +2,8 @@ import logging
 
 from flask import request
 from flask_restplus import Resource, inputs, marshal
-from biolink.datamodel.serializers import node, named_object, bio_object, association_results, association, disease_object
+from biolink.datamodel.serializers import node, named_object, bio_object,\
+    association_results, association, disease_object, d2p_association_results
 #import biolink.datamodel.serializers
 from biolink.api.restplus import api
 from ontobio.golr.golr_associations import search_associations, select_distinct_subjects
@@ -481,7 +482,7 @@ class GeneCaseAssociations(Resource):
 class DiseasePhenotypeAssociations(Resource):
 
     @api.expect(core_parser_with_relation_filter)
-    @api.marshal_with(association_results)
+    @api.marshal_with(d2p_association_results)
     def get(self, id):
         """
         Returns phenotypes associated with disease

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -182,6 +182,18 @@ association_results = api.inherit('AssociationResults', search_result, {
     'objects': fields.List(fields.String, description='List of distinct objects used')
 })
 
+d2p_association = api.inherit('D2PAssociation', association, {
+    'frequency': fields.Nested(entity_reference, description='Frequency of phenotype in patients with disease', required=False),
+    'onset': fields.Nested(entity_reference, description='Onset of phenotype in disease process', required=False)
+})
+
+# A search result that returns a set of associations
+d2p_association_results = api.inherit('AssociationResults', search_result, {
+    'associations': fields.List(fields.Nested(d2p_association), description='Complete representation of full association object, plus evidence'),
+    'compact_associations': fields.List(fields.Nested(compact_association_set), description='Compact representation in which objects (e.g. phenotypes) are collected for subject-predicate pairs'),
+    'objects': fields.List(fields.String, description='List of distinct objects used')
+})
+
 
 # Bio Objects
 

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -188,10 +188,8 @@ d2p_association = api.inherit('D2PAssociation', association, {
 })
 
 # A search result that returns a set of associations
-d2p_association_results = api.inherit('AssociationResults', search_result, {
-    'associations': fields.List(fields.Nested(d2p_association), description='Complete representation of full association object, plus evidence'),
-    'compact_associations': fields.List(fields.Nested(compact_association_set), description='Compact representation in which objects (e.g. phenotypes) are collected for subject-predicate pairs'),
-    'objects': fields.List(fields.String, description='List of distinct objects used')
+d2p_association_results = api.inherit('AssociationResults', association_results, {
+    'associations': fields.List(fields.Nested(d2p_association), description='Complete representation of full association object, plus evidence')
 })
 
 

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -183,16 +183,21 @@ association_results = api.inherit('AssociationResults', search_result, {
 })
 
 d2p_association = api.inherit('D2PAssociation', association, {
-    'frequency': fields.Nested(entity_reference, description='Frequency of phenotype in patients with disease', required=False),
-    'onset': fields.Nested(entity_reference, description='Onset of phenotype in disease process', required=False)
+    'frequency': fields.Nested(entity_reference,
+                               description='Frequency of phenotype in patients with disease', required=False),
+    'onset': fields.Nested(entity_reference,
+                           description='Onset of phenotype in disease process', required=False)
 })
 
 # A search result that returns a set of associations
+# plus specific fields for disease to phenotype (frequency and onset)
 d2p_association_results = api.inherit('AssociationResults', association_results, {
-    'associations': fields.List(fields.Nested(d2p_association), description='Complete representation of full association object, plus evidence')
+    'associations': fields.List(fields.Nested(d2p_association),
+                                description='Complete representation of full disease '
+                                            'to phenotype association, plus evidence')
 })
 
-
+#############
 # Bio Objects
 
 sequence_position = api.model('SequencePosition', {


### PR DESCRIPTION
This PR accompanies https://github.com/biolink/ontobio/pull/336 and adds frequency and onset to flask_restplus for disease to phenotype associatons