### PR TITLE
Fix bioentityset routes

### DIFF
--- a/biolink/api/entityset/endpoints/geneset_homologs.py
+++ b/biolink/api/entityset/endpoints/geneset_homologs.py
@@ -18,17 +18,18 @@ parser.add_argument('subject', action='append', help='Entity ids to be examined,
 class EntitySetHomologs(Resource):
 
     @api.expect(parser)
-    @api.marshal_list_with(compact_association_set)
+    @api.marshal_list_with(association_results)
     def get(self):
         """
         Returns homology associations for a given input set of genes
         """
         args = parser.parse_args()
-
+        subjects = args['subject']
+        del args['subject']
         M=GolrFields()
         rel = 'RO:0002434'  # TODO; allow other types
         results = search_associations(
-            subjects=args.get('subject'),
+            subjects=subjects,
             select_fields=[M.SUBJECT, M.RELATION, M.OBJECT],
             use_compact_associations=True,
             relation=rel,

--- a/biolink/api/entityset/endpoints/overrepresentation.py
+++ b/biolink/api/entityset/endpoints/overrepresentation.py
@@ -55,9 +55,5 @@ class OverRepresentation(Resource):
         background = args.get('background')
         afactory = AssociationSetFactory()
         aset = afactory.create(ontology=ont, subject_category='gene', object_category=ocat, taxon=taxid)
-        enr = aset.enrichment_test(subjects=subjects, threshold=max_p_value, labels=True)
-        return {'results':enr}
-
-    
-    
-
+        enr = aset.enrichment_test(subjects=subjects, background=background, threshold=max_p_value, labels=True)
+        return {'results': enr }

--- a/biolink/api/entityset/endpoints/summary.py
+++ b/biolink/api/entityset/endpoints/summary.py
@@ -28,10 +28,11 @@ class EntitySetSummary(Resource):
         Summary statistics for objects associated
         """
         args = parser.parse_args()
-
+        subjects = args.get('subject')
+        del args['subject']
         M=GolrFields()
         results = search_associations(
-            subjects=args.get('subject'),
+            subjects=subjects,
             rows=0,
             facet_fields=[M.OBJECT_CLOSURE, M.IS_DEFINED_BY],
             facet_limit=-1,
@@ -47,7 +48,6 @@ class EntitySetAssociations(Resource):
 
     @api.expect(parser)
     @api.marshal_list_with(association_results)
-    #@api.marshal_list_with(compact_association_set)
     def get(self):
         """
         Returns compact associations for a given input set
@@ -55,9 +55,10 @@ class EntitySetAssociations(Resource):
         args = parser.parse_args()
 
         M=GolrFields()
-
+        subjects = args.get('subject')
+        del args['subject']
         results = search_associations(
-            subjects=args.get('subject'),
+            subjects=subjects,
             select_fields=[M.SUBJECT, M.RELATION, M.OBJECT],
             use_compact_associations=True,
             rows=MAX_ROWS,


### PR DESCRIPTION
This PR fixes the following routes, 
- `bioentityset/homologs`
- `bioentityset/associations`
- `bioentityset/overrepresentation`

Although, the `bioentityset/overrepresentation` route needs more work. This ought to be worked on after enrichment modules are improved in Ontobio.