### PR TITLE
add freq and onset to PhenotypeDiseaseAssociations

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -725,7 +725,7 @@ class PhenotypeAnatomyAssociations(Resource):
 class PhenotypeDiseaseAssociations(Resource):
 
     @api.expect(core_parser_with_relation_filter)
-    @api.marshal_with(association_results)
+    @api.marshal_with(d2p_association_results)
     def get(self, id):
         """
         Returns diseases associated with a phenotype


### PR DESCRIPTION
Adds frequency and onset to PhenotypeDiseaseAssociations, eg /api/bioentity/phenotype/HP:0001994/disease/?fetch_objects=true&start=5&rows=10