### PR TITLE
Fixes for Monarch UI

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -360,7 +360,7 @@ class GeneFunctionAssociations(Resource):
                     user_agent=USER_AGENT,
                     **core_parser.parse_args()
                 )
-                assocs['associations'] += pr_assocs['associations']
+                assocs = pr_assocs
         return assocs
 
 @api.doc(params={'id': 'CURIE identifier of gene, e.g. NCBIGene:4750'})

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -60,16 +60,17 @@ summary_property_value = api.inherit('SummaryPropertyValue', abstract_property_v
 association_property_value = api.inherit('AssociationPropertyValue', abstract_property_value, {
 })
 
-
 node = api.model('Node', {
     'id': fields.String(readOnly=True, description='ID or CURIE'),
-    'lbl': fields.String(readOnly=True, description='human readable label, maps to rdfs:label')
+    'lbl': fields.String(readOnly=True, description='human readable label, maps to rdfs:label'),
+    'meta': fields.Raw(description='metadata about the Node')
 })
 
 edge = api.model('Edge', {
     'sub': fields.String(readOnly=True, description='Subject (source) Node ID'),
     'pred': fields.String(readOnly=True, description='Predicate (relation) ID'),
     'obj': fields.String(readOnly=True, description='Object (target) Node ID'),
+    'meta': fields.Raw(description='metadata about the Edge')
 })
 
 bbop_graph = api.model('Graph', {


### PR DESCRIPTION
This PR address the following:
- Fix bug where `numFound` is always 0 when fetching gene-function associations
- Fix bug where node and edge `meta` was missing from the `evidence_graph`