### PR TITLE
Add filter for causal and non-causal gene to disease associations

### DIFF
--- a/tests/bioentity-disease.feature
+++ b/tests/bioentity-disease.feature
@@ -35,6 +35,27 @@ Feature: Disease entity queries work as expected
         Given a path "/bioentity/disease/DOID:9455/genes?rows=0&fetch_objects=true&facet=true"
         then the content should contain "HGNC:14537"
 
+## Disease to Gene causal associations
+
+    Scenario: User queries for causal genes associated with Marfan Syndrome
+        Given a path "/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=causal"
+        then the JSON should have some JSONPath "associations[0].object.label" with "string" "FBN1"
+        then the JSON should have some JSONPath "numFound" with "integer" "1"
+
+## Disease to Gene non causal associations
+
+    Scenario: User queries for non causal genes associated with Marfan Syndrome
+        Given a path "/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=non_causal"
+        then the JSON should not have some JSONPath "associations[*].object.label" with "string" "FBN1"
+        then the JSON should have some JSONPath "associations[*].object.label" with "string" "TGFBR2"
+
+## Disease to Gene all associations
+
+    Scenario: User queries for all genes associated with Marfan Syndrome
+        Given a path "/bioentity/disease/MONDO:0007947/genes?rows=10"
+        then the JSON should have some JSONPath "associations[*].object.label" with "string" "FBN1"
+        then the JSON should have some JSONPath "associations[*].object.label" with "string" "TGFBR2"
+
 ## Disease to Phenotype associations
 
     Scenario: User queries for phenotypes associated with a disease

--- a/tests/steps/route-data.py
+++ b/tests/steps/route-data.py
@@ -223,6 +223,38 @@ def step_impl(context, jsonpath, thing, value):
                     assert True is False
             assert is_found is True
 
+
+@then('the JSON should not have some JSONPath "{jsonpath}" with "{thing}" "{value}"')
+def step_impl(context, jsonpath, thing, value):
+    if not context.content_json :
+        ## Apparently no JSON at all...
+        assert True is False
+    else:
+        jsonpath_expr = jsonpath_rw.parse(jsonpath)
+        results = jsonpath_expr.find(context.content_json)
+        if (len(results)) == 0:
+            assert True is False
+        else:
+            is_found = False
+            for res in results:
+                if thing == "string":
+                    if res.value == value:
+                        is_found = True
+                elif thing == "integer":
+                    if res.value == int(value):
+                        is_found = True
+                elif thing == "boolean":
+                    if res.value == bool(value):
+                        is_found = True
+                elif thing == "float":
+                    if res.value == float(value):
+                        is_found = True
+                else:
+                    ## Not a thing we know how to deal with yet.
+                    logging.error("Cannot interpret: {}".format(thing))
+                    assert True is False
+            assert is_found is False
+
 @then('the JSON should have some JSONPath "{jsonpath}" containing "{thing}" "{value}"')
 def step_impl(context, jsonpath, thing, value):
     if not context.content_json :


### PR DESCRIPTION
Adds filter for causal and non-causal gene to disease associations and a few corresponding behave tests

Closes #274 

Testing locally:
http://127.0.0.1:5000/api/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=causal
http://127.0.0.1:5000/api/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=non_causal
http://127.0.0.1:5000/api/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=both
http://127.0.0.1:5000/api/bioentity/disease/MONDO:0007947/genes?rows=10

note that travis failed twice on
  tests/bioentity-function.feature:5  User fetches all GO functional assignments for a zebrafish gene
