### PR TITLE
Fix bug where get_association_counts was failing for certain diseases

### DIFF
--- a/biolink/api/bio/association_counts.py
+++ b/biolink/api/bio/association_counts.py
@@ -43,7 +43,6 @@ CATEGORY_NAME_MAP = {
     'variant_gene': {
         'variant': 'gene',
         'gene': 'variant'
-
     },
     "variant_genotype": {
         'variant': 'genotype',
@@ -100,6 +99,10 @@ CATEGORY_NAME_MAP = {
     "pathway_phenotype": {
         'pathway': 'phenotype',
         'phenotype': 'pathway'
+    },
+    "disease_pathway": {
+        'pathway': 'disease',
+        'disease': 'pathway'
     },
     "gene_temporal": {},
     "model_case": {


### PR DESCRIPTION
Fixes bug where the API was throwing error when getting association counts for diseases.

URL to tests: http://localhost:5000/api/bioentity/disease/MONDO%3A0007947?rows=100&facet=false&unselect_evidence=false&exclude_automatic_assertions=false&fetch_objects=false&use_compact_associations=false&get_association_counts=true

**Note:** This PR should be tested against `solr-dev.monarchinitiative.org/solr/golr`

@kshefchek Would be good to get your input on all possible values that `association_type` can have. I may have to account for all of these when getting the counts.