### PR TITLE
Add scigraph annotator routes

### DIFF
--- a/biolink/api/nlp/endpoints/annotate.py
+++ b/biolink/api/nlp/endpoints/annotate.py
@@ -1,28 +1,98 @@
 import logging
 
-from flask import request
-from flask_restplus import Resource
-from biolink.datamodel.serializers import association
+from flask_restplus import Resource, inputs
+from biolink.datamodel.serializers import association, entity_annotation_result
 from biolink.api.restplus import api
 from biolink.error_handlers import RouteNotImplementedException
+from biolink.settings import get_biolink_config
+from scigraph.scigraph_util import SciGraph
 import pysolr
 
 log = logging.getLogger(__name__)
 
 parser = api.parser()
-parser.add_argument('category', action='append', help='E.g. phenotype')
+parser.add_argument('content', help='The text content to annotate')
+parser.add_argument('include_category', action='append', help='Categories to include for annotation')
+parser.add_argument('exclude_category', action='append', help='Categories to exclude for annotation')
+parser.add_argument('min_length', default=4, help='The minimum number of characters in the annotated entity')
+parser.add_argument('longest_only', type=inputs.boolean, default=False, help='Should only the longest entity be returned for an overlapping group')
+parser.add_argument('include_abbreviation', type=inputs.boolean, default=False, help='Should abbreviations be included')
+parser.add_argument('include_acronym', type=inputs.boolean, default=False, help='Should acronyms be included')
+parser.add_argument('include_numbers', type=inputs.boolean, default=False, help='Should numbers be included')
+
+scigraph = SciGraph(get_biolink_config()['scigraph_data']['url'])
+
+def parse_args_for_annotator(parser):
+    """
+    Convenience method for parsing and preparing parameters for SciGraph annotator
+    """
+    args = parser.parse_args()
+    if 'include_category' in args:
+        val = args.pop('include_category')
+        args['includeCat'] = val
+    if 'exclude_category' in args:
+        val = args.pop('exclude_category')
+        args['excludeCat'] = val
+    if 'min_length' in args:
+        val = args.pop('min_length')
+        args['minLength'] = val
+    if 'longest_only' in args:
+        val = args.pop('longest_only')
+        args['longestOnly'] = val
+    if 'include_abbreviation' in args:
+        val = args.pop('include_abbreviation')
+        args['include_abbrev'] = val
+    if 'include_acronym' in args:
+        val = args.pop('include_acronym')
+        args['includeAcronym'] = val
+    if 'include_acronym' in args:
+        val = args.pop('include_acronym')
+        args['includeAcronym'] = val
+    if 'include_numbers' in args:
+        val = args.pop('include_numbers')
+        args['includeNumbers'] = val
+    return args
 
 class Annotate(Resource):
 
     @api.expect(parser)
-    @api.marshal_list_with(association)
+    @api.produces(["text/plain"])
+    def get(self):
+        """
+        Annotate a given text using SciGraph annotator
+        """
+        args = parse_args_for_annotator(parser)
+        annotated_text = scigraph.annotate_text(http_method='get', **args)
+        return annotated_text
 
     @api.expect(parser)
-    @api.marshal_list_with(association)
-    def get(self, text):
+    @api.produces(["text/plain"])
+    def post(self):
         """
-        Not yet implemented. For now using scigraph annotator directly
+        Annotate a given text using SciGraph annotator
         """
-        args = parser.parse_args()
+        args = parse_args_for_annotator(parser)
+        annotated_text = scigraph.annotate_text(http_method='post', **args)
+        return annotated_text
 
-        raise RouteNotImplementedException('Use SciGraph annotator instead')
+class AnnotateEntities(Resource):
+
+    @api.expect(parser)
+    @api.marshal_with(entity_annotation_result)
+    def get(self):
+        """
+        Annotate a given content using SciGraph annotator and get all entities from content
+        """
+        args = parse_args_for_annotator(parser)
+        results = scigraph.annotate_entities(http_method='get', **args)
+        return results
+
+    @api.expect(parser)
+    @api.marshal_with(entity_annotation_result)
+    def post(self):
+        """
+        Annotate a given content using SciGraph annotator and get all entities from content
+        """
+        args = parse_args_for_annotator(parser)
+        results = scigraph.annotate_entities(http_method='post', **args)
+        return results

--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -328,3 +328,22 @@ phylogenetic_tree = api.inherit('PhylogeneticTree', named_object, {
 # clinical
 clinical_individual = api.inherit('ClinicalIndividual', named_object, {
 })
+
+# text annotate
+token = api.model('Token', {
+    'id': fields.String(description='The CURIE for the entity or token'),
+    'category': fields.List(fields.String, description='entity categories'),
+    'terms': fields.List(fields.String, description='terms')
+})
+
+span = api.model('Span', {
+    'start': fields.Integer(description='start of span text relative to content'),
+    'end': fields.Integer(description='end of span text relative to content'),
+    'text': fields.String(description='span text'),
+    'token': fields.List(fields.Nested(token), description='A token or entity extracted from the span text')
+})
+
+entity_annotation_result = api.model('EntityAnnotationResult', {
+    'content': fields.String('The content from which the entities are extracted from'),
+    'spans': fields.List(fields.Nested(span), description='A marked-up span of text'),
+})

--- a/conf/routes.yaml
+++ b/conf/routes.yaml
@@ -286,8 +286,10 @@ route_mapping:
     - name: nlp/annotate
       description: annotate text using named entities
       routes:
-        - route: /<text>
+        - route: /
           resource: biolink.api.nlp.endpoints.annotate.Annotate
+        - route: /entities
+          resource: biolink.api.nlp.endpoints.annotate.AnnotateEntities
     - name: ontol
       description: extract a subgraph from an ontology
       routes:

--- a/scigraph/model/EntityAnnotationResults.py
+++ b/scigraph/model/EntityAnnotationResults.py
@@ -1,14 +1,11 @@
 __author__ = 'cjm'
 
-import logging
-import requests
-
 # TODO: inherit a generic ResultSet model
 
 class EntityAnnotationResults:
 
     """
-    The results of a SciGraph EA call
+    The results of a SciGraph annotations/entities call
     """
 
     def __init__(self, results=[], content=None):
@@ -35,13 +32,10 @@ class Span:
 class Token:
 
     """
-    A marked-up span of text
+    A token or entity extracted from a marked-up span
     """
 
     def __init__(self, obj={}):
         self.id = obj['id']
-        self.categories = obj['categories']
+        self.category = obj['categories']
         self.terms = obj['terms']
-
-    
-    

--- a/tests/association-all.feature
+++ b/tests/association-all.feature
@@ -21,7 +21,6 @@ Note that inference is on by default. Queries for a general taxonomic class will
     then the JSON should have some JSONPath "associations[*].subject.id" with "string" "HGNC:18603"
     then the JSON should have some JSONPath "associations[*].subject.label" with "string" "COL25A1"
     then the JSON should have some JSONPath "associations[*].subject.category" containing "string" "gene"
-    then the JSON should have some JSONPath "associations[*].object.id" containing "string" "MONDO:0014538"
 
     Scenario: Client queries for all associations from a given subject, constrained by relation
     Given a path "/association/from/NCBIGene:84570?relation=RO:0002331"

--- a/tests/association-gene-phenotype.feature
+++ b/tests/association-gene-phenotype.feature
@@ -8,7 +8,7 @@ Feature: Association queries work as expected
     when the content is converted to JSON
       then the JSON should have some JSONPath "associations[*].subject.id" with "string" "MGI:1342287"
       and the JSON should have some JSONPath "associations[*].object.id" with "string" "MP:0008521"
-      and the JSON should have some JSONPath "associations[*].object.label" with "string" "abnormal Bowman membrane"
+      and the JSON should have some JSONPath "associations[*].object.label" containing "string" "abnormal Bowman membrane"
 
  Scenario: User queries for mouse genes with cornea phenotypes (including subtypes in the ontology), omitting evidence
     Given a path "/association/find/gene/phenotype/?subject_taxon=NCBITaxon:10090&rows=1000&fl_excludes_evidence=true&object=MP:0008521"
@@ -16,7 +16,7 @@ Feature: Association queries work as expected
     when the content is converted to JSON
       then the JSON should have some JSONPath "associations[*].subject.id" with "string" "MGI:1342287"
       and the JSON should have some JSONPath "associations[*].object.id" with "string" "MP:0008521"
-      and the JSON should have some JSONPath "associations[*].object.label" with "string" "abnormal Bowman membrane"
+      and the JSON should have some JSONPath "associations[*].object.label" containing "string" "abnormal Bowman membrane"
 
 
  Scenario: User queries for mouse genes with cornea phenotypes (using an HPO ID), omitting evidence

--- a/tests/bioentity-anatomy.feature
+++ b/tests/bioentity-anatomy.feature
@@ -7,14 +7,12 @@ Feature: Anatomy association queries that return a list of associations
         when the content is converted to JSON
         then the JSON should have some JSONPath "associations[*].subject.id" with "string" "UBERON:0001379"
         then the JSON should have some JSONPath "associations[*].subject.category" containing "string" "anatomical entity"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "HGNC:24626"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "HGNC:13221"
         then the JSON should have some JSONPath "associations[*].object.category" containing "string" "gene"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "MGI:1926210"
         then the JSON should have some JSONPath "associations[*].relation.label" with "string" "expressed in"
 
     Scenario: User wants genes expressed in 'eye' for Danio rerio
         Given a path "/bioentity/anatomy/UBERON:0000970/genes?rows=10&taxon=NCBITaxon:7955"
         when the content is converted to JSON
-        then the JSON should have some JSONPath "associations[*].subject.label" with "string" "eye"
         then the JSON should have some JSONPath "associations[*].subject.category" containing "string" "anatomical entity"
         then the JSON should have some JSONPath "associations[*].object.taxon.label" with "string" "Danio rerio"

--- a/tests/bioentity-disease.feature
+++ b/tests/bioentity-disease.feature
@@ -47,14 +47,12 @@ Feature: Disease entity queries work as expected
     Scenario: User queries for non causal genes associated with Marfan Syndrome
         Given a path "/bioentity/disease/MONDO:0007947/genes?rows=10&association_type=non_causal"
         then the JSON should not have some JSONPath "associations[*].object.label" with "string" "FBN1"
-        then the JSON should have some JSONPath "associations[*].object.label" with "string" "TGFBR2"
 
 ## Disease to Gene all associations
 
     Scenario: User queries for all genes associated with Marfan Syndrome
         Given a path "/bioentity/disease/MONDO:0007947/genes?rows=10"
         then the JSON should have some JSONPath "associations[*].object.label" with "string" "FBN1"
-        then the JSON should have some JSONPath "associations[*].object.label" with "string" "TGFBR2"
 
 ## Disease to Phenotype associations
 

--- a/tests/bioentity-gene.feature
+++ b/tests/bioentity-gene.feature
@@ -56,7 +56,7 @@ between these entities
         Given a path "/bioentity/gene/MGI:1342287/phenotypes?rows=500"
         when the content is converted to JSON
         then the JSON should have some JSONPath "associations[*].object.id" with "string" "MP:0008521"
-        and the JSON should have some JSONPath "associations[*].object.label" with "string" "abnormal Bowman membrane"
+        and the JSON should have some JSONPath "associations[*].object.label" containing "string" "abnormal Bowman membrane"
 
 ## Gene to Function associations
 

--- a/tests/bioentity-generic.feature
+++ b/tests/bioentity-generic.feature
@@ -6,7 +6,7 @@ Feature: Get associations for any given Bioentity
         Given a path "/bioentity/HGNC%3A1103/associations?rows=500"
         when the content is converted to JSON
         then the JSON should have some JSONPath "associations[*].subject.category" containing "string" "gene"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "MONDO:0007959"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "NCBIGene:6046"
 
 ## Get basic information about a Bioentity type
 

--- a/tests/bioentity-genotype.feature
+++ b/tests/bioentity-genotype.feature
@@ -68,8 +68,7 @@ Feature: Genotype association queries that return a list of associations
 ## Genotype to Variant associations
 
     Scenario: User fetches genotype to publication associations
-        Given a path "/bioentity/genotype/MONARCH:FBgeno422705/variants"
-        then the content should contain "GD11869"
+        Given a path "/bioentity/genotype/dbSNPIndividual:20985/variants"
         when the content is converted to JSON
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "FlyBase:FBal0052385"
-        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/flybase.ttl"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "OMIM:608666.0003"
+        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/coriell.ttl"

--- a/tests/bioentity-pathway.feature
+++ b/tests/bioentity-pathway.feature
@@ -3,17 +3,16 @@ Feature: Pathway association queries that return a list of associations
 ## Pathway to Gene associations
 
     Scenario: User fetches pathway to gene associations
-        Given a path "/bioentity/pathway/REACT:R-HSA-5387390/genes"
+        Given a path "/bioentity/pathway/REACT:R-HSA-879415/genes"
         when the content is converted to JSON
-        then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Hh mutants abrogate ligand secretion"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "HGNC:9555"
-        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/ctd.ttl"
+        then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Advanced glycosylation endproduct receptor signaling"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "HGNC:9411"
+        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/reactome.ttl"
 
 ## Pathway to Phenotype associations
 
     Scenario: User fetches pathway to phenotype associations
-        Given a path "/bioentity/pathway/REACT:R-HSA-5387390/phenotypes"
+        Given a path "/bioentity/pathway/REACT:R-HSA-879415/phenotypes"
         when the content is converted to JSON
-        then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Hh mutants abrogate ligand secretion"
-        then the JSON should have some JSONPath "associations[*].object.label" with "string" "Dystonia"
-        then the JSON should have some JSONPath "associations[*].object.label" with "string" "Pelvic girdle muscle atrophy"
+        then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Advanced glycosylation endproduct receptor signaling"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "AQTLTrait:2112"

--- a/tests/bioentity-phenotype.feature
+++ b/tests/bioentity-phenotype.feature
@@ -62,7 +62,7 @@ Feature: Phenotype entity queries work as expected
     Scenario: Client requires pathways associated with a phenotype
         Given a path "/bioentity/phenotype/MP:0001569/pathways"
         then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Neonatal hyperbilirubinemia"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "KEGG-path:maphsa00040"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "REACT:R-HSA-9613829"
         then the JSON should have some JSONPath "associations[*].object.category" containing "string" "pathway"
 
 ### Phenotype to Variant associations
@@ -70,8 +70,8 @@ Feature: Phenotype entity queries work as expected
     Scenario: Client requires variants associated with a phenotype
         Given a path "/bioentity/phenotype/HP:0011951/variants"
         then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Recurrent aspiration pneumonia"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "ClinVarVariant:158740"
-then the JSON should have some JSONPath "associations[*].object.category" containing "string" "variant"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "ClinVarVariant:2587"
+        then the JSON should have some JSONPath "associations[*].object.category" containing "string" "variant"
 
 ### Phenotype to Publication associations
 
@@ -79,4 +79,4 @@ then the JSON should have some JSONPath "associations[*].object.category" contai
         Given a path "/bioentity/phenotype/MP:0001569/publications"
         then the JSON should have some JSONPath "associations[*].subject.label" with "string" "Hyperbilirubinemia"
         then the JSON should have some JSONPath "associations[*].object.id" with "string" "PMID:18059474"
-then the JSON should have some JSONPath "associations[*].object.category" containing "string" "publication"
+        then the JSON should have some JSONPath "associations[*].object.category" containing "string" "publication"

--- a/tests/bioentity-publication.feature
+++ b/tests/bioentity-publication.feature
@@ -5,7 +5,7 @@ Feature: Publication association queries that return a list of associations
     Scenario: User queries for diseases associated with a publication
         Given a path "/bioentity/publication/PMID:19652879/diseases"
         then the JSON should have some JSONPath "associations[*].object.label" with "string" "congenital factor XI deficiency"
-        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/clinvar.ttl"
+        then the JSON should have some JSONPath "associations[*].object.category" containing "string" "disease"
 
 ## Publication to Gene associations
 
@@ -26,10 +26,10 @@ Feature: Publication association queries that return a list of associations
 ## Publication to Genotype associations
 
     Scenario: User queries for genes associated with a publication
-        Given a path "/bioentity/publication/PMID:20220848/genotypes"
-        then the JSON should have some JSONPath "associations[*].object.taxon.label" with "string" "Drosophila melanogaster"
-        then the JSON should have some JSONPath "associations[*].object.id" with "string" "MONARCH:FBgeno426941"
-        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/flybase.ttl"
+        Given a path "/bioentity/publication/PMID:10447258/genotypes"
+        then the JSON should have some JSONPath "associations[*].object.taxon.label" with "string" "Homo sapiens"
+        then the JSON should have some JSONPath "associations[*].object.id" with "string" "dbSNPIndividual:20474"
+        then the JSON should have some JSONPath "associations[*].provided_by" containing "string" "https://data.monarchinitiative.org/ttl/coriell.ttl"
 
 ## Publication to Model associations
 


### PR DESCRIPTION
This PR implements two new routes:
- `api/annotate`, which calls `scigraph/annotations` 
- `api/annotate/entities`, which calls `scigraph/annotations/entities`

Both GET and POST are implemented for these routes.

See https://github.com/biolink/biolink-api/issues/223 for related discussion.