### PR TITLE
add has_part, inheres_in_part_of to phenotype anatomy

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -737,10 +737,9 @@ class PhenotypeAnatomyAssociations(Resource):
         Example IDs:
 
          * MP:0008521 abnormal Bowman membrane
-
-        For example, *abnormal limb development* will map to *limb*
         """
-        objs = scigraph.phenotype_to_entity_list(id)
+        clique_leader = scigraph.get_clique_leader(id)
+        objs = scigraph.phenotype_to_entity_list(clique_leader.id)
         return objs
 
 @api.doc(params={'id': 'CURIE identifier of phenotype, e.g. HP:0007359. Equivalent IDs can be used with same results'})

--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -18,6 +18,7 @@ from biolink.error_handlers import NoResultFoundException
 
 HAS_PART = 'http://purl.obolibrary.org/obo/BFO_0000051'
 INHERES_IN = 'http://purl.obolibrary.org/obo/RO_0000052'
+INHERES_IN_PART_OF = 'http://purl.obolibrary.org/obo/RO_0002314'
 HAS_ROLE = 'http://purl.obolibrary.org/obo/RO_0000087'
 IN_TAXON = 'RO:0002162'
 HAS_DISPOSITION = 'RO:0000091'
@@ -364,7 +365,13 @@ class SciGraph:
 
         Uses the Ontology Design Pattern has-part o inheres_in
         """
-        objs = self.traverse_chain(id, [HAS_PART, INHERES_IN], "anatomical entity")
+        inheres_in = self.traverse_chain(id,
+                                         [HAS_PART, INHERES_IN],
+                                         "anatomical entity")
+        inheres_in_part_of = self.traverse_chain(id,
+                                                 [HAS_PART, INHERES_IN_PART_OF],
+                                                 "anatomical entity")
+        objs = inheres_in + inheres_in_part_of
         return [self.make_NamedObject(id=x.id, lbl=x.lbl, meta={}, class_name='NamedObject') for x in objs]
 
     def substance_to_role_associations(self, id):

--- a/tests/bioentity-phenotype.feature
+++ b/tests/bioentity-phenotype.feature
@@ -26,6 +26,11 @@ Feature: Phenotype entity queries work as expected
         then the content should contain "nose"
         and the content should contain "UBERON:0000004"
 
+    Scenario: Client requires mapping between MP:0008521 (MP) and anatomy
+        Given a path "/bioentity/phenotype/MP:0008521/anatomy"
+        then the content should contain "anterior limiting lamina of cornea"
+        and the content should contain "UBERON:0004370"
+
 # TODO: This will always fail until bioentity/phenotype/<id>/anatomy route is fixed
 # Scenario: Client requires mapping between phenotype (ZP) and anatomy
 #    Given a path "/bioentity/phenotype/ZP:0004204/anatomy"


### PR DESCRIPTION
Our API docs use abnormal Bowman membrane as an example ID for phenotype anatomy, however this does not work because we're not querying the property chain has_part, inheres_in_part_of.  This PR adds this 