### PR TITLE
Add a configurable service specific identifier converter

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -12,8 +12,8 @@ from ontobio.vocabulary.relations import HomologyTypes
 from ..closure_bins import create_closure_bin
 from ..association_counts import get_association_counts
 from biolink import USER_AGENT
-from biolink.api.entityset.endpoints.slimmer import gene_to_uniprot_from_mygene, uniprot_to_gene_from_mygene
-from biolink.settings import get_biolink_config
+
+from biolink.settings import get_biolink_config, get_identifier_converter
 from biolink.error_handlers import NoResultFoundException, UnhandledException, UnrecognizedBioentityTypeException
 
 from ontobio.golr.golr_query import run_solr_text_on, ESOLR, ESOLRDoc, replace
@@ -85,6 +85,7 @@ scigraph = SciGraph(get_biolink_config()['scigraph_data']['url'])
 
 homol_rel = HomologyTypes.Homolog.value
 
+identifier_converter = get_identifier_converter()
 
 @api.doc(params={'id': 'id, e.g. NCBIGene:84570'})
 class GenericObject(Resource):
@@ -362,8 +363,7 @@ class GeneFunctionAssociations(Resource):
         if len(assocs['associations']) == 0:
             # Note that GO currently uses UniProt as primary ID for some sources: https://github.com/biolink/biolink-api/issues/66
             # https://github.com/monarch-initiative/dipper/issues/461
-            #prots = scigraph.gene_to_uniprot_proteins(id)
-            prots = gene_to_uniprot_from_mygene(id)
+            prots = identifier_converter.convert_gene_to_protein(id)
             for prot in prots:
                 pr_assocs = search_associations(
                     object_category='function',

--- a/biolink/identifier_converter.py
+++ b/biolink/identifier_converter.py
@@ -1,0 +1,82 @@
+import logging
+from biolink.settings import get_biolink_config
+from scigraph.scigraph_util import SciGraph
+from biothings_client import get_client
+
+
+class SciGraphIdentifierConverter(object):
+    """
+    Class for performing ID conversion using SciGraph
+    """
+    def __init__(self):
+        self.scigraph = SciGraph(get_biolink_config()['scigraph_data']['url'])
+
+    def convert_gene_to_protein(self, identifier):
+        """
+        Query SciGraph with a gene ID and get its corresponding UniProtKB ID
+        """
+        protein_ids = self.scigraph.gene_to_uniprot_proteins(identifier)
+        return protein_ids
+
+    def convert_protein_to_gene(self, identifier):
+        """
+        Query SciGraph with UniProtKB ID and get its corresponding HGNC gene ID
+        """
+        gene_ids = self.scigraph.uniprot_protein_to_genes(identifier)
+        return gene_ids
+
+
+class MyGeneInfoIdentifierConverter(object):
+    """
+    Class for performing ID conversion using MyGeneInfo
+    """
+    def __init__(self):
+        self.mygene_client = get_client('gene')
+
+    def convert_gene_to_protein(self, identifier):
+        """
+        Query MyGeneInfo with a gene ID and get its corresponding UniProtKB ID
+        """
+        uniprot_ids = []
+        if identifier.startswith('NCBIGene:'):
+            # MyGeneInfo uses 'entrezgene' prefix instead of 'NCBIGene'
+            identifier = identifier.replace('NCBIGene', 'entrezgene')
+        try:
+            results = self.mygene_client.query(identifier, fields='uniprot')
+            if results['hits']:
+                for hit in results['hits']:
+                    if 'Swiss-Prot' in hit['uniprot']:
+                        uniprot_id = hit['uniprot']['Swiss-Prot']
+                        if not uniprot_id.startswith('UniProtKB'):
+                            uniprot_id = "UniProtKB:{}".format(uniprot_id)
+                        uniprot_ids.append(uniprot_id)
+                    else:
+                        trembl_ids = hit['uniprot']['TrEMBL']
+                        for x in trembl_ids:
+                            if not x.startswith('UniProtKB'):
+                                x = "UniProtKB:{}".format(x)
+                            uniprot_ids.append(x)
+        except ConnectionError:
+            logging.error("ConnectionError while querying MyGeneInfo with {}".format(identifier))
+
+        return uniprot_ids
+
+    def convert_protein_to_gene(self, identifier):
+        """
+        Query MyGeneInfo with UniProtKB ID and get its corresponding HGNC gene ID
+        """
+        gene_id = None
+        if identifier.startswith('UniProtKB'):
+            identifier = identifier.split(':', 1)[1]
+
+        try:
+            results = self.mygene_client.query(identifier, fields='HGNC')
+            if results['hits']:
+                hit = results['hits'][0]
+                gene_id = hit['HGNC']
+                if not gene_id.startswith('HGNC'):
+                    gene_id = 'HGNC:{}'.format(gene_id)
+        except ConnectionError:
+            logging.error("ConnectionError while querying MyGeneInfo with {}".format(identifier))
+
+        return [gene_id]

--- a/biolink/settings.py
+++ b/biolink/settings.py
@@ -1,4 +1,5 @@
 import yaml
+import importlib
 from os import path, environ
 
 # Flask settings
@@ -25,6 +26,7 @@ CONFIG = path.join(path.dirname(path.abspath(__file__)), '../conf/config.yaml')
 ROUTES = path.join(path.dirname(path.abspath(__file__)), '../conf/routes.yaml')
 biolink_config = None
 route_mapping = None
+identifier_converter = None
 
 def get_biolink_config():
     global biolink_config
@@ -39,3 +41,11 @@ def get_route_mapping():
         with open(ROUTES, 'r') as FH:
             route_mapping = yaml.load(FH, Loader=yaml.FullLoader)
     return route_mapping
+
+def get_identifier_converter():
+    global identifier_converter
+    if identifier_converter is None:
+        module_name, class_name = get_biolink_config()['identifier_converter'].rsplit(".", 1)
+        MyClass = getattr(importlib.import_module(module_name), class_name)
+        identifier_converter = MyClass()
+    return identifier_converter

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -21,6 +21,9 @@ scigraph_data:
   timeout: 15
 use_amigo_for:
   - function
+identifier_converter: biolink.identifier_converter.SciGraphIdentifierConverter
+#identifier_converter: biolink.identifier_converter.MyGeneInfoIdentifierConverter
+
 ontologies:
   - id: go
     handle: go


### PR DESCRIPTION
This PR adds two identifier converter classes, one for SciGraph and another for MyGene.
Both these classes have `convert_gene_to_proteins` and `convert_protein_to_gene` methods.

Which identifier converter to use is determined by `conf/config.yaml`.

The purpose of doing this is to allow flexibility in service that each implementation uses.

For Monarch, the conversion is done via SciGraph.
For GO, the conversion is done via MyGene.

If there is a new implementation of the BioLink API that needs to use another service, then one can add a new class and refer to that in `config.yaml`.

@cmungall @kshefchek Would like your feedback on the approach used 