### PR TITLE
Fix missing taxon filter for gene/<id>/variants route

### DIFF
--- a/biolink/api/bio/endpoints/bioentity.py
+++ b/biolink/api/bio/endpoints/bioentity.py
@@ -477,6 +477,7 @@ class GeneVariantAssociations(Resource):
             subject_category='gene',
             object_category='variant',
             invert_subject_object=True,
+            object_taxon=args.taxon,
             subject=id,
             user_agent=USER_AGENT,
             **args


### PR DESCRIPTION
Addresses the bug raised in https://github.com/monarch-initiative/monarch-ui/issues/168#issuecomment-545953372