### PR TITLE
Ensure that all datasets are returned by metadata/datasets route

### DIFF
--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -421,10 +421,7 @@ class SciGraph:
         """
         response = self.get_response("dynamic/ontologies", None, "json")
         response_json = response.json()
-        datasets = []
-        for n in response_json['nodes']:
-            if 'MonarchData' in n['id']:
-                datasets.append(n)
+        datasets = response_json['nodes']
         return datasets
 
 def bbg_to_assocs(g):


### PR DESCRIPTION
This PR fixes a poor assumption made earlier where the datasets returned by SciGraph was being filtered to get only datasets and no OWLs. 
Instead, now the metadata/datasets route will return all datasets (OWL included) such that filtering of the dataset list can be done after the fact.

@kshefchek @justaddcoffee FYI
