### PR TITLE
Amend metadata datasets route

### DIFF
--- a/scigraph/scigraph_util.py
+++ b/scigraph/scigraph_util.py
@@ -419,10 +419,9 @@ class SciGraph:
         """
         Get metadata about all the datasets in SciGraph
         """
-        response = self.get_response("dynamic/ontologies", None, "json")
+        response = self.get_response("dynamic/datasets", None, "json")
         response_json = response.json()
-        datasets = response_json['nodes']
-        return datasets
+        return response_json
 
 def bbg_to_assocs(g):
     return [bbedge_to_assoc(e,g) for e in g.edges]

--- a/tests/metadata-datasets.feature
+++ b/tests/metadata-datasets.feature
@@ -1,0 +1,12 @@
+Feature: Getting metadata for datasets
+
+ Scenario: Validate metadata for datasets
+    Given a path "/metadata/datasets"
+     when the content is converted to JSON
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcterms:Publisher"
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcterms:isVersionOf"
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcat:Distribution"
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcterms:creator"
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcterms:source"
+     then the JSON should have some JSONPath "edges[*].pred" with "string" "dcterms:downloadURL"
+


### PR DESCRIPTION
This PR ensures that the `metadata/datasets` route now calls scigraph `dynamic/datasets` endpoint instead of `dynamic/ontologies`.

Also added a test that basically checks if the response contains certain edges. The check is very cursory at the moment. 

@kshefchek @justaddcoffee