### PR TITLE
Add fq to autocomplete endpoint

### DIFF
--- a/biolink/api/bio/association_counts.py
+++ b/biolink/api/bio/association_counts.py
@@ -123,8 +123,8 @@ CATEGORY_NAME_MAP = {
         'model': 'publication'
     },
     "marker_disease": {
-        'gene': 'noncausal-disease',
-        'disease': 'noncausal-gene',
+        'gene': 'correlated-disease',
+        'disease': 'correlated-gene',
         'ortholog': 'disease'
     },
     "case_disease": {

--- a/biolink/api/search/endpoints/entitysearch.py
+++ b/biolink/api/search/endpoints/entitysearch.py
@@ -14,6 +14,10 @@ def get_simple_parser():
         A simple flaskrest parser object that includes basic http params
         """
         p = api.parser()
+        p.add_argument('fq_string', action='append', required=False,
+                       help='fq string passed directly to solr, note that multiple filters '
+                            'will be combined with an AND operator. Combining fq_string with '
+                            'other parameters may result in unexpected behavior.')
         p.add_argument('category', action='append', help='e.g. gene, disease')
         p.add_argument('prefix', action='append', help='ontology prefix: HP, -MONDO')
         p.add_argument('boost_fx', action='append', help='boost function e.g. pow(edges,0.334)')

--- a/biolink/api/search/endpoints/entitysearch.py
+++ b/biolink/api/search/endpoints/entitysearch.py
@@ -1,4 +1,5 @@
 import logging
+import copy
 
 from flask_restplus import Resource, inputs
 from biolink.api.restplus import api
@@ -14,7 +15,7 @@ def get_simple_parser():
         A simple flaskrest parser object that includes basic http params
         """
         p = api.parser()
-        p.add_argument('fq_string', action='append', required=False,
+        p.add_argument('fq', action='append', required=False,
                        help='fq string passed directly to solr, note that multiple filters '
                             'will be combined with an AND operator. Combining fq_string with '
                             'other parameters may result in unexpected behavior.')
@@ -125,6 +126,8 @@ class Autocomplete(Resource):
         Returns list of matching concepts or entities using lexical search
         """
         args = simple_parser.parse_args()
+        args['fq_string'] = copy.copy(args['fq'])
+        args['fq'] = {}
         q = GolrSearchQuery(term, user_agent=USER_AGENT, **args)
         results = q.autocomplete()
         return results

--- a/biolink/api/sim/endpoints/semanticsim.py
+++ b/biolink/api/sim/endpoints/semanticsim.py
@@ -7,7 +7,7 @@ from biolink.api.restplus import api
 from biolink.datamodel.sim_serializers import sim_result, compare_input
 
 sim_engine = PhenoSimEngine(OwlSim2Api())
-metrics = [matcher.value for matcher in sim_engine.sim_api.matchers()]
+metrics = [matcher.value for matcher in OwlSim2Api.matchers()]
 
 # Common args
 sim_parser = api.parser()


### PR DESCRIPTION
Adds fq param to autocomplete to support complex filters.  This is needed for the phenotype profile search autocomplete in which we want to filter solr with
(category:phenotype OR (category:gene AND (prefix:HGNC OR has_phenotype:true)) (category:disease AND has_phenotype:true))