### PR TITLE
Renames 'category' to 'categories' in datamodel.serializers

### DIFF
--- a/biolink/datamodel/serializers.py
+++ b/biolink/datamodel/serializers.py
@@ -333,7 +333,7 @@ clinical_individual = api.inherit('ClinicalIndividual', named_object, {
 # text annotate
 token = api.model('Token', {
     'id': fields.String(description='The CURIE for the entity or token'),
-    'category': fields.List(fields.String, description='entity categories'),
+    'categories': fields.List(fields.String, description='entity categories'),
     'terms': fields.List(fields.String, description='terms')
 })
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 prefixcommons>=0.0
-ontobio>=2.7.14
+# ontobio>=2.7.14
+git+https://github.com/falquaddoomi/ontobio.git@7894361056bf87a69cacb8cefcf10ac4f51f2924#egg=ontobio
 pip>=9.0.1
 wheel>0.25.0
+itsdangerous==2.0.1
 Flask==1.1.2
 flask-restplus>=0.10.1
 Flask-SQLAlchemy>=2.1


### PR DESCRIPTION
This PR changes the `category` field to `categories`, which is also an issue upstream in ontobio, i.e. https://github.com/biolink/ontobio/issues/615. I've submitted a PR for the fix in ontobio (https://github.com/biolink/ontobio/pull/616), but until that goes through I've switched the dependency in `requirements.txt` from the PyPI ontobio version to my custom version that includes the fix. I can of course remove my ad-hoc requirement if need be.

`itsdangerous` was also pinned to a specific version to circumvent an issue that's been fixed in later versions of Flask.